### PR TITLE
feat: Added support for config-slug in the apis

### DIFF
--- a/portkey/__init__.py
+++ b/portkey/__init__.py
@@ -30,7 +30,7 @@ from portkey.api_resources.global_constants import (
 
 api_key = os.environ.get(PORTKEY_API_KEY_ENV)
 base_url = os.environ.get(PORTKEY_PROXY_ENV, PORTKEY_BASE_URL)
-config: Optional[Config] = None
+config: Optional[Union[Config, str]] = None
 mode: Optional[Union[Modes, ModesLiteral]] = None
 __version__ = VERSION
 __all__ = [

--- a/portkey/api_resources/base_client.py
+++ b/portkey/api_resources/base_client.py
@@ -21,6 +21,7 @@ from .global_constants import PORTKEY_HEADER_PREFIX
 from .utils import (
     remove_empty_values,
     Body,
+    ConfigSlug,
     Options,
     RequestConfig,
     OverrideParams,
@@ -127,7 +128,7 @@ class APIClient:
         self,
         path: str,
         *,
-        body: Union[List[Body], Any],
+        body: Union[List[Body], Any, ConfigSlug],
         mode: str,
         cast_to: Type[ResponseT],
         stream: bool,
@@ -187,7 +188,7 @@ class APIClient:
         *,
         method: str,
         url: str,
-        body: List[Body],
+        body: Union[List[Body], ConfigSlug],
         mode: str,
         stream: bool,
         params: Params,
@@ -196,8 +197,13 @@ class APIClient:
         opts.method = method
         opts.url = url
         params_dict = {} if params is None else params.dict()
+        config = (
+            body.config
+            if isinstance(body, ConfigSlug)
+            else self._config(mode, body).dict()
+        )
         json_body = {
-            "config": self._config(mode, body).dict(),
+            "config": config,
             "params": {**params_dict, "stream": stream},
         }
         opts.json_body = remove_empty_values(json_body)

--- a/portkey/api_resources/utils.py
+++ b/portkey/api_resources/utils.py
@@ -145,7 +145,6 @@ class ModelParams(BaseModel):
     n: Optional[int] = None
     stop_sequences: Optional[List[str]] = None
     timeout: Union[float, None] = None
-    retry_settings: Optional[RetrySettings] = None
     functions: Optional[List[Function]] = None
     function_call: Optional[Union[None, str, Function]] = None
     logprobs: Optional[int] = None
@@ -232,6 +231,10 @@ class RequestConfig(BaseModel):
 
 class Body(LLMOptions):
     ...
+
+
+class ConfigSlug(BaseModel):
+    config: str
 
 
 class Params(ConversationInput, ModelParams, extra="forbid"):
@@ -496,7 +499,7 @@ def default_base_url() -> str:
     raise ValueError(MISSING_BASE_URL)
 
 
-def retrieve_config() -> Config:
+def retrieve_config() -> Union[Config, str]:
     if portkey.config:
         return portkey.config
     raise ValueError(MISSING_CONFIG_MESSAGE)


### PR DESCRIPTION
# Summary
This pull request addresses the need to simplify configuration management by introducing support for configSlug instead of requiring the manual construction of the entire config within the codebase. By allowing users to reference pre-configured settings via a configSlug, we aim to reduce the amount of code users need to write and encourage the reuse of configurations across different codebases.

**Changes**
- Added a new feature that supports the usage of configSlug as a reference to pre-configured settings.
- Modified relevant code sections to incorporate this new feature.

Fixes: #29 