### PR TITLE
Rename prompt to prompts.

### DIFF
--- a/portkey_ai/__init__.py
+++ b/portkey_ai/__init__.py
@@ -20,7 +20,7 @@ from portkey_ai.api_resources import (
     TextCompletion,
     TextCompletionChunk,
     createHeaders,
-    Prompt,
+    Prompts,
     Portkey,
 )
 from portkey_ai.version import VERSION
@@ -60,6 +60,6 @@ __all__ = [
     "base_url",
     "PORTKEY_GATEWAY_URL",
     "createHeaders",
-    "Prompt",
+    "Prompts",
     "Portkey",
 ]

--- a/portkey_ai/api_resources/__init__.py
+++ b/portkey_ai/api_resources/__init__.py
@@ -3,7 +3,7 @@ from .apis import (
     Completion,
     ChatCompletion,
     Generations,
-    Prompt,
+    Prompts,
     Feedback,
     createHeaders,
 )
@@ -50,7 +50,7 @@ __all__ = [
     "TextCompletion",
     "TextCompletionChunk",
     "Generations",
-    "Prompt",
+    "Prompts",
     "Feedback",
     "createHeaders",
     "Portkey",

--- a/portkey_ai/api_resources/apis/__init__.py
+++ b/portkey_ai/api_resources/apis/__init__.py
@@ -1,6 +1,6 @@
 from .chat_complete import ChatCompletion
 from .complete import Completion
-from .generation import Generations, Prompt
+from .generation import Generations, Prompts
 from .feedback import Feedback
 from .create_headers import createHeaders
 from .post import Post
@@ -11,7 +11,7 @@ __all__ = [
     "ChatCompletion",
     "Generations",
     "Feedback",
-    "Prompt",
+    "Prompts",
     "createHeaders",
     "Post",
     "Embeddings",

--- a/portkey_ai/api_resources/apis/generation.py
+++ b/portkey_ai/api_resources/apis/generation.py
@@ -44,7 +44,7 @@ class Generations(APIResource):
         return response
 
 
-class Prompt(APIResource):
+class Prompts(APIResource):
     completions: Completions
 
     def __init__(self, client: APIClient) -> None:

--- a/portkey_ai/api_resources/client.py
+++ b/portkey_ai/api_resources/client.py
@@ -9,7 +9,7 @@ class Portkey(APIClient):
     completions: apis.Completion
     chat: apis.ChatCompletion
     generations: apis.Generations
-    prompt: apis.Prompt
+    prompts: apis.Prompts
     embeddings: apis.Embeddings
 
     def __init__(
@@ -38,7 +38,7 @@ class Portkey(APIClient):
         self.completions = apis.Completion(self)
         self.chat = apis.ChatCompletion(self)
         self.generations = apis.Generations(self)
-        self.prompts = apis.Prompt(self)
+        self.prompts = apis.Prompts(self)
         self.embeddings = apis.Embeddings(self)
         self.feedback = apis.Feedback(self)
 

--- a/portkey_ai/version.py
+++ b/portkey_ai/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.0.0"
+VERSION = "1.0.1"


### PR DESCRIPTION
**Title:** Rename prompt class to prompts

**Description:**
- Rename prompt class to prompts, to comply with docs.

**Motivation:**
It was a bug, didn't follow the documentation.

**Related Issues:**
#61 