### PR TITLE
Expose streaming attribute from PortkeyLLM and ChatPortkey (Langhchain)

### DIFF
--- a/portkey_ai/llms/langchain/chat.py
+++ b/portkey_ai/llms/langchain/chat.py
@@ -116,6 +116,7 @@ class ChatPortkey(SimpleChatModel):
     provider: Optional[str] = None
     trace_id: Optional[str] = None
     custom_metadata: Optional[str] = None
+    streaming: bool = False
 
     def __init__(
         self,

--- a/portkey_ai/llms/langchain/completion.py
+++ b/portkey_ai/llms/langchain/completion.py
@@ -54,6 +54,7 @@ class PortkeyLLM(LLM):
     provider: Optional[str] = None
     trace_id: Optional[str] = None
     custom_metadata: Optional[str] = None
+    streaming: bool = False
 
     def __init__(
         self,


### PR DESCRIPTION
**Title:** Expose streaming attribute from PortkeyLLM and ChatPortkey (Langhchain)

**Description:**
- Expose streaming parameter from Langchain PortkeyLLM and ChatPortkey so that Langchain can consider it as stream enabled LLM

**Motivation:**
This change is necessary to support stream mode in LLamaIndex x Langchain Integration

**Related Issues:**
#64 