### PR TITLE
chore: update typing extensions version constraint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
   httpx
   mypy==0.991
   black==23.7.0
-  typing_extensions==4.7.1
+  typing_extensions>=4.7.1,<5.0
   pydantic>=1.10.12
 
 [options.entry_points]
@@ -36,7 +36,7 @@ console_scripts =
 dev =
   mypy==0.991
   black==23.7.0
-  typing_extensions==4.7.1
+  typing_extensions>=4.7.1,<5.0
   pydantic>=1.10.12
   pytest==7.4.2
   python-dotenv==1.0.0


### PR DESCRIPTION
**Title:** update typing extensions version constraint in setup.cfg

**Description:**
- Update typing dependencies version constraints from strict ==4.7.1 to >=4.7.1,<5.0 to resolve dependency conflict with package like chroma

**Motivation:**
To avoid any dependency conflict with packages that internally require a higher version of typing dependencies

**Related Issues:**
Closes #67 
Closes #66 