### PR TITLE
fix: add default value in optional field for pydantic v2 compatibility

### DIFF
--- a/portkey_ai/api_resources/utils.py
+++ b/portkey_ai/api_resources/utils.py
@@ -450,9 +450,9 @@ class TextCompletionChunk(BaseModel, extra="allow"):
 
 
 class GenericResponse(BaseModel, extra="allow"):
-    success: Optional[bool]
-    data: Optional[Any]
-    warning: Optional[str]
+    success: Optional[bool] = None
+    data: Optional[Any] = None
+    warning: Optional[str] = None
     _headers: Optional[httpx.Headers] = None
 
     def __str__(self):


### PR DESCRIPTION
**Title:** Add default values for Optional properties for pydantic v2 compatibility

**Description:**
- Add default None for Optional properties in GenericResponse class

**Motivation:**
To be compatible with the new Optional definition of pydantic v2

**Related Issues:**
- Closes #73 