### PR TITLE
hotfix: openAI as dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
   black==23.7.0
   typing_extensions>=4.7.1,<5.0
   pydantic>=1.10.12
+  openai>=1.0,<2.0
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
**Title:** Hotfix OpenAI dependency 

**Description:**
- adding OpenAI as install_requires 


**Related Issues:**
#102 