### PR TITLE
fix: private attribute changes for pydantic v1 compatibility

### DIFF
--- a/portkey_ai/api_resources/types/assistant_type.py
+++ b/portkey_ai/api_resources/types/assistant_type.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Union
 import httpx
 from .utils import parse_headers
 from typing import List, Any
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 
 __all__ = [
     "Assistant",
@@ -45,7 +45,7 @@ class Assistant(BaseModel):
     name: Optional[str] = None
     object: Optional[str]
     tools: Optional[List[Tool]]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -64,7 +64,7 @@ class Assistant(BaseModel):
 class AssistantList(BaseModel, extra="allow"):
     object: Optional[str]
     data: Optional[List[Assistant]]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -84,7 +84,7 @@ class AssistantDeleted(BaseModel, extra="allow"):
     id: Optional[str]
     object: Optional[str]
     deleted: Optional[bool]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -99,7 +99,7 @@ class AssistantFile(BaseModel, extra="allow"):
     assistant_id: Optional[str]
     created_at: Optional[int]
     object: Optional[str]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -115,7 +115,7 @@ class AssistantFileList(BaseModel, extra="allow"):
     first_id: Optional[str]
     last_id: Optional[str]
     has_more: Optional[bool]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -129,7 +129,7 @@ class AssistantFileDeleted(BaseModel, extra="allow"):
     id: Optional[str]
     deleted: Optional[bool]
     object: Optional[str]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers

--- a/portkey_ai/api_resources/types/chat_complete_type.py
+++ b/portkey_ai/api_resources/types/chat_complete_type.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 import httpx
 from .utils import parse_headers
 from typing import List, Any
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 
 __all__ = [
     "ChatCompletions",
@@ -111,7 +111,7 @@ class ChatCompletions(BaseModel):
     object: Optional[str]
     system_fingerprint: Optional[str] = None
     usage: Optional[Usage] = None
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers

--- a/portkey_ai/api_resources/types/complete_type.py
+++ b/portkey_ai/api_resources/types/complete_type.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 import httpx
 from .utils import parse_headers
 from typing import List, Any
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 
 __all__ = ["CompletionUsage", "Logprobs", "CompletionChoice", "TextCompletion"]
 
@@ -36,7 +36,7 @@ class TextCompletion(BaseModel):
     object: Optional[str]
     system_fingerprint: Optional[str] = None
     usage: Optional[CompletionUsage] = None
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers

--- a/portkey_ai/api_resources/types/embeddings_type.py
+++ b/portkey_ai/api_resources/types/embeddings_type.py
@@ -4,7 +4,7 @@ import httpx
 
 from .utils import parse_headers
 from typing import List, Any
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 
 __all__ = ["CreateEmbeddingResponse", "Usage", "Embedding"]
 
@@ -28,7 +28,7 @@ class CreateEmbeddingResponse(BaseModel):
     model: Optional[str]
     object: Optional[str]
     usage: Usage
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers

--- a/portkey_ai/api_resources/types/generation_type.py
+++ b/portkey_ai/api_resources/types/generation_type.py
@@ -12,7 +12,7 @@ from portkey_ai.api_resources.types.complete_type import Logprobs, TextChoice
 
 from .utils import parse_headers
 from typing import List, Any
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 
 
 class PromptCompletion(BaseModel):
@@ -27,7 +27,7 @@ class PromptCompletion(BaseModel):
     text: Optional[str] = None
     logprobs: Optional[Logprobs] = None
     finish_reason: Optional[str] = None
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         return json.dumps(self.dict(), indent=4)

--- a/portkey_ai/api_resources/types/image_type.py
+++ b/portkey_ai/api_resources/types/image_type.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 import httpx
 from .utils import parse_headers
 from typing import List, Any
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 
 __all__ = ["ImagesResponse", "Image"]
 
@@ -17,7 +17,7 @@ class Image(BaseModel):
 class ImagesResponse(BaseModel):
     created: Optional[int]
     data: List[Image]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers

--- a/portkey_ai/api_resources/types/main_file_type.py
+++ b/portkey_ai/api_resources/types/main_file_type.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 import httpx
 from .utils import parse_headers
 from typing import List, Any
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 
 __all__ = ["FileObject", "FileList", "FileDeleted"]
 
@@ -17,7 +17,7 @@ class FileObject(BaseModel):
     purpose: Optional[str]
     status: Optional[str]
     status_details: Optional[str] = None
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -36,7 +36,7 @@ class FileObject(BaseModel):
 class FileList(BaseModel):
     object: Optional[str]
     data: List[FileObject]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -56,7 +56,7 @@ class FileDeleted(BaseModel):
     id: Optional[str]
     deleted: Optional[bool]
     object: Optional[str]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers

--- a/portkey_ai/api_resources/types/models_type.py
+++ b/portkey_ai/api_resources/types/models_type.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 import httpx
 from .utils import parse_headers
 from typing import List, Any
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 
 __all__ = ["Model", "ModelDeleted", "ModelList"]
 
@@ -13,7 +13,7 @@ class Model(BaseModel):
     created: Optional[int]
     object: Optional[str]
     owned_by: Optional[str]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -32,7 +32,7 @@ class Model(BaseModel):
 class ModelList(BaseModel, extra="allow"):
     object: Optional[str]
     data: List[Model]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -46,7 +46,7 @@ class ModelDeleted(BaseModel):
     id: Optional[str]
     deleted: Optional[bool]
     object: Optional[str]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers

--- a/portkey_ai/api_resources/types/thread_message_type.py
+++ b/portkey_ai/api_resources/types/thread_message_type.py
@@ -2,7 +2,7 @@ import json
 from typing import Dict, List, Optional, Union
 import httpx
 from .utils import parse_headers
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 
 __all__ = [
     "ThreadMessage",
@@ -81,7 +81,7 @@ class ThreadMessage(BaseModel, extra="allow"):
     role: Optional[str]
     run_id: Optional[str] = None
     thread_id: Optional[str]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -97,7 +97,7 @@ class MessageList(BaseModel, extra="allow"):
     first_id: Optional[str]
     last_id: Optional[str]
     has_more: Optional[bool]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -112,7 +112,7 @@ class MessageFile(BaseModel, extra="allow"):
     object: Optional[str]
     created_at: Optional[int]
     message_id: Optional[str]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers

--- a/portkey_ai/api_resources/types/thread_run_type.py
+++ b/portkey_ai/api_resources/types/thread_run_type.py
@@ -3,7 +3,7 @@ from typing import Dict, Literal, Optional, Union
 import httpx
 from .utils import parse_headers
 from typing import List
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 
 __all__ = [
     "Run",
@@ -183,7 +183,7 @@ class Run(BaseModel):
     thread_id: Optional[str]
     tools: Optional[List[Tool]]
     usage: Optional[Usage] = None
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -199,7 +199,7 @@ class RunList(BaseModel, extra="allow"):
     first_id: Optional[str]
     last_id: Optional[str]
     has_more: Optional[bool]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -226,7 +226,7 @@ class RunStep(BaseModel, extra="allow"):
     thread_id: Optional[str]
     type: Optional[str]
     usage: Optional[Usage] = None
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -242,7 +242,7 @@ class RunStepList(BaseModel, extra="allow"):
     first_id: Optional[str]
     last_id: Optional[str]
     has_more: Optional[bool]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers

--- a/portkey_ai/api_resources/types/thread_type.py
+++ b/portkey_ai/api_resources/types/thread_type.py
@@ -2,7 +2,7 @@ import json
 from typing import Dict, Optional
 import httpx
 from .utils import parse_headers
-from pydantic import BaseModel
+from pydantic import BaseModel, PrivateAttr
 
 
 __all__ = ["Thread", "ThreadDeleted"]
@@ -13,7 +13,7 @@ class Thread(BaseModel, extra="allow"):
     created_at: Optional[int]
     metadata: Optional[object] = None
     object: Optional[str]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers
@@ -27,7 +27,7 @@ class ThreadDeleted(BaseModel, extra="allow"):
     id: Optional[str]
     object: Optional[str]
     deleted: Optional[bool]
-    _headers: Optional[httpx.Headers] = None
+    _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
         del self._headers


### PR DESCRIPTION
**Title:** 
fix: private attribute changes for pydantic v1 compatibility

**Description:**
- Use PrivateAttr from pydantic for _headers in all class

**Motivation:**
- Pydantic v1 compatibility

**Related Issues:**
- Fixes #115  