### PR TITLE
hotfix: openai version lock

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
   mypy>=0.991,<2.0
   typing_extensions>=4.7.1,<5.0
   pydantic>=1.10.12
-  openai>=1.0,<2.0
+  openai>=1.0,<=1.20.0
 
 [options.entry_points]
 console_scripts =
@@ -42,7 +42,7 @@ dev =
   python-dotenv==1.0.0
   ruff==0.0.292
   pytest-asyncio==0.23.5
-  openai>=1.0,<2.0
+  openai>=1.0,<=1.20.0
 
 [mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
**Title:** OpenAI Version lock

**Description:**
- To support OpenAI upto a particular version
- beta.assistants.file .message.files etc support issue

**Related Issues:**
#119 