### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
+        make dev
     - name: Build package
       run: make build
     - name: Publish package


### PR DESCRIPTION
**Title:** Release workflow

**Description:**
- Issue: `mypy` was not installed for `make build` to run
- Not only for `mypy`, would have been an issue for `black` and `ruff` as well
- Have to run `make dev` while installing dependencies

**Motivation:**
Avoids the manual effort to publish the package

**Related Issues:**
#159 