### PR TITLE
Hotfix: prompt rendor response type

### DIFF
--- a/portkey_ai/api_resources/types/chat_complete_type.py
+++ b/portkey_ai/api_resources/types/chat_complete_type.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Optional
+from typing import Dict, Iterable, Optional, Union
 import httpx
 from .utils import parse_headers
 from typing import List, Any
@@ -73,7 +73,7 @@ class ChatCompletionMessageToolCall(BaseModel):
 
 
 class ChatCompletionMessage(BaseModel):
-    content: Optional[str] = None
+    content: Optional[Union[str, Iterable[Any]]] = None
     role: Optional[str]
     function_call: Optional[FunctionCall] = None
     tool_calls: Optional[List[ChatCompletionMessageToolCall]] = None


### PR DESCRIPTION
**Title:** prompt rendor response type

**Description:**
- Added Union of string and Iterable Any for the content.message

**Motivation:**
Issue reported by user on Discord (https://discord.com/channels/1143393887742861333/1253676373302710335/1253827484160626788)

**Related Issues:**
Closes #170 