### PR TITLE
fix: /lib for vendoring

### DIFF
--- a/portkey_ai/version.py
+++ b/portkey_ai/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.6.0"
+VERSION = "1.7.0rc"

--- a/portkey_ai/version.py
+++ b/portkey_ai/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.7.0rc"
+VERSION = "1.7.0rc1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,10 @@ console_scripts =
   portkey_ai = portkey_ai._portkey_scripts:main
 
 [options.package_data]
-  portkey_ai = py.typed
+  portkey_ai = 
+    py.typed
+    _vendor/openai/lib/*
+    _vendor/openai/lib/streaming/*
 
 [options.extras_require]
 dev =
@@ -60,3 +63,6 @@ exclude = portkey_ai/_vendor/*
 exclude =
   tests/
   tests.*
+include =
+  portkey_ai
+  portkey_ai.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,3 @@ exclude = portkey_ai/_vendor/*
 exclude =
   tests/
   tests.*
-include =
-  portkey_ai
-  portkey_ai.*


### PR DESCRIPTION
**Title:** Building Package issue

**Description:**
- /lib under Vendoring not being added to build 
- force adding in setup.cfg

**Related Issues:**
Closes #176