### PR TITLE
Max Retries 

### DIFF
--- a/portkey_ai/api_resources/client.py
+++ b/portkey_ai/api_resources/client.py
@@ -103,6 +103,7 @@ class Portkey(APIClient):
             base_url=self.base_url,
             default_headers=self.allHeaders,
             http_client=http_client,
+            max_retries=0,
         )
 
         self.completions = apis.Completion(self)

--- a/portkey_ai/api_resources/client.py
+++ b/portkey_ai/api_resources/client.py
@@ -280,6 +280,7 @@ class AsyncPortkey(AsyncAPIClient):
             base_url=self.base_url,
             default_headers=self.allHeaders,
             http_client=http_client,
+            max_retries=0,
         )
 
         self.completions = apis.AsyncCompletion(self)


### PR DESCRIPTION
**Title:** Default retries to zero

**Description:**
- Setting `max_retries = 0` where we initialise the client

**Motivation:**
To avoid default max retries which is equal to 3

**Related Issues:**
Closes: #181 