### PR TITLE
Allow token_logprobs and top_logprobs List to have Objects of None type

### DIFF
--- a/portkey_ai/api_resources/types/complete_type.py
+++ b/portkey_ai/api_resources/types/complete_type.py
@@ -16,9 +16,9 @@ class CompletionUsage(BaseModel):
 
 class Logprobs(BaseModel):
     text_offset: Optional[List[int]] = None
-    token_logprobs: Optional[List[float]] = None
+    token_logprobs: Optional[List[Optional[float]]] = None
     tokens: Optional[List[str]] = None
-    top_logprobs: Optional[List[Dict[str, float]]] = None
+    top_logprobs: Optional[List[Optional[Dict[str, float]]]] = None
 
 
 class CompletionChoice(BaseModel):


### PR DESCRIPTION
**Title:** 
Update types for token_logprobs and top_logprobs inside Completion Response

**Description:**
- Refer https://github.com/Portkey-AI/gateway/issues/463 for original issue report

**Motivation:**
OpenAI SDK returns the response object as is, so there is no type checking by Pydantic, it's inferred on the client side and hence doesn't fail withe openAI SDK
Whereas portkey-sdk manipulates the object and Pydantic check fails

Example OpenAI Response
```
{
  "id": "cmpl-9nlcqIQdJrv3sqCf8L69Pn3LWrkMI",
  "object": "text_completion",
  "created": 1721648172,
  "model": "davinci-002",
  "choices": [
    {
      "text": "What is the current temperature in San Francisco? also set light brightness to 50 and color to warm white and these cool lights wont work in the car. It’s possible that your",
      "index": 0,
      "logprobs": {
        "tokens": [
          "What",
          " is",
          " the"
        ],
        "token_logprobs": [
          None,
          -1.8412793,
          -1.1794527,
        ],
        "top_logprobs": [
          None,
          {
            " is": -1.8412793,
            " are": -2.5893137
          },
          {
            " the": -1.1794527,
            " your": -2.4726083
          }], "
            text_offset
            ": [0, 4, 7, 11, 19, 31, 34, 38, 48, 49, 54, 58, 64, 75, 78, 79, 81, 85, 91, 94, 99, 105, 109, 115, 120, 127, 132, 137, 140, 144, 148, 149, 152, 154, 163, 168]}, "
            finish_reason
            ": "
            length
            "}], "
            usage
            ": {"
            prompt_tokens
            ": 20, "
            completion_tokens
            ": 16, "
            total_tokens
            ": 36}}
```

**Related Issues:**
https://github.com/Portkey-AI/gateway/issues/463

**Testing Done:**
- Tested by invoking chat.completions.create and completions.create on the client