### PR TITLE
Making API Key optional is self hosted gateway

### DIFF
--- a/portkey_ai/api_resources/base_client.py
+++ b/portkey_ai/api_resources/base_client.py
@@ -82,8 +82,8 @@ class APIClient:
         mistral_fim_completion: Optional[str] = None,
         **kwargs,
     ) -> None:
-        self.api_key = api_key or default_api_key()
         self.base_url = base_url or default_base_url()
+        self.api_key = api_key or default_api_key(self.base_url)
         self.virtual_key = virtual_key
         self.config = config
         self.provider = provider
@@ -723,8 +723,8 @@ class AsyncAPIClient:
         mistral_fim_completion: Optional[str] = None,
         **kwargs,
     ) -> None:
-        self.api_key = api_key or default_api_key()
         self.base_url = base_url or default_base_url()
+        self.api_key = api_key or default_api_key(self.base_url)
         self.virtual_key = virtual_key
         self.config = config
         self.provider = provider

--- a/portkey_ai/api_resources/utils.py
+++ b/portkey_ai/api_resources/utils.py
@@ -433,13 +433,15 @@ class Config(BaseModel):
         return llms
 
 
-def default_api_key() -> str:
+def default_api_key(base_url) -> str:
     if portkey_ai.api_key:
         return portkey_ai.api_key
     env_api_key = os.environ.get(PORTKEY_API_KEY_ENV, "")
-    if env_api_key:
-        return env_api_key
-    raise ValueError(MISSING_API_KEY_ERROR_MESSAGE)
+    if base_url == PORTKEY_BASE_URL:
+        if env_api_key:
+            return env_api_key
+        raise ValueError(MISSING_API_KEY_ERROR_MESSAGE)
+    return env_api_key
 
 
 def default_base_url() -> str:


### PR DESCRIPTION
**Title:** Making API Key optional is self hosted gateway

**Description:**
- Checking if it is not PORTKEY_BASE_URL then keep api_key optional


**Related Issues:**
Fixes: #136