### PR TITLE
Pydantic install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
   httpx
   mypy>=0.991,<2.0
   typing_extensions>=4.7.1,<5.0
-  pydantic>=1.10.12
+  pydantic>=1.10.0
   anyio>=3.5.0,<5
   distro>=1.7.0,<2
   sniffio
@@ -46,7 +46,7 @@ dev =
   mypy>=0.991,<2.0
   black==23.7.0
   typing_extensions>=4.7.1,<5.0
-  pydantic>=1.10.12
+  pydantic>=1.10.0
   pytest==7.4.2
   python-dotenv==1.0.0
   ruff==0.0.292


### PR DESCRIPTION
**Title:** Pydantic install_requires range

**Description:**
- Reducing the range of pydantic to >=1.10.0

**Motivation:**
Issue for a user for integration

**Related Issues:**
Fixes: #232 