### PR TITLE
Pydantic for v1 and v2

### DIFF
--- a/portkey_ai/api_resources/apis/__init__.py
+++ b/portkey_ai/api_resources/apis/__init__.py
@@ -1,3 +1,10 @@
+"""
+The following change is brought to handle the cases for pydantic v1 and v2
+Including (import sys) and
+sys.modules["openai"] = vendored_openai
+"""
+import sys
+from ..._vendor import openai as vendored_openai
 from .chat_complete import ChatCompletion, AsyncChatCompletion
 from .complete import Completion, AsyncCompletion
 from .generation import Generations, AsyncGenerations, Prompts, AsyncPrompts
@@ -79,6 +86,8 @@ from .configs import Configs, AsyncConfigs
 from .api_keys import ApiKeys, AsyncApiKeys
 from .virtual_keys import VirtualKeys, AsyncVirtualKeys
 from .logs import Logs, AsyncLogs
+
+sys.modules["openai"] = vendored_openai  # For pydantic v1 and v2 compatibility
 
 __all__ = [
     "Completion",

--- a/portkey_ai/api_resources/apis/beta_chat.py
+++ b/portkey_ai/api_resources/apis/beta_chat.py
@@ -1,9 +1,7 @@
 from typing import Any, Union
-from portkey_ai._vendor.openai.types.chat.parsed_chat_completion import (
-    ParsedChatCompletion,
-)
 from portkey_ai.api_resources.apis.api_resource import APIResource, AsyncAPIResource
 from portkey_ai.api_resources.client import AsyncPortkey, Portkey
+from portkey_ai.api_resources.types.beta_chat_type import ParsedChatCompletion
 from ..._vendor.openai._types import NotGiven, NOT_GIVEN
 
 
@@ -27,7 +25,7 @@ class BetaCompletions(APIResource):
         response_format: Union[Any, NotGiven] = NOT_GIVEN,
         tools: Union[Any, NotGiven] = NOT_GIVEN,
         **kwargs: Any,
-    ) -> ParsedChatCompletion[Any]:
+    ) -> ParsedChatCompletion:
         response = self.openai_client.beta.chat.completions.parse(
             messages=messages,
             model=model,
@@ -35,7 +33,7 @@ class BetaCompletions(APIResource):
             tools=tools,
             extra_body=kwargs,
         )
-        return response
+        return response  # type: ignore [return-value]
 
     def stream(
         self,
@@ -85,7 +83,7 @@ class AsyncBetaCompletions(AsyncAPIResource):
         response_format: Union[Any, NotGiven] = NOT_GIVEN,
         tools: Union[Any, NotGiven] = NOT_GIVEN,
         **kwargs: Any,
-    ) -> ParsedChatCompletion[Any]:
+    ) -> ParsedChatCompletion:
         response = await self.openai_client.beta.chat.completions.parse(
             messages=messages,
             model=model,
@@ -93,7 +91,7 @@ class AsyncBetaCompletions(AsyncAPIResource):
             tools=tools,
             extra_body=kwargs,
         )
-        return response
+        return response  # type: ignore [return-value]
 
     async def stream(
         self,

--- a/portkey_ai/api_resources/types/api_keys_type.py
+++ b/portkey_ai/api_resources/types/api_keys_type.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, PrivateAttr
 from portkey_ai.api_resources.types.utils import parse_headers
 
 
-class ApiKeyAddResponse(BaseModel):
+class ApiKeyAddResponse(BaseModel, extra="allow"):
     id: Optional[str]
     key: Optional[str]
     object: Optional[str]
@@ -24,7 +24,7 @@ class ApiKeyAddResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class ApiKeyGetResponse(BaseModel):
+class ApiKeyGetResponse(BaseModel, extra="allow"):
     id: Optional[str]
     key: Optional[str]
     name: Optional[str]
@@ -58,7 +58,7 @@ class ApiKeyGetResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class ApiKeyListResponse(BaseModel):
+class ApiKeyListResponse(BaseModel, extra="allow"):
     object: Optional[str]
     total: Optional[int]
     data: Optional[List[Dict[str, Any]]]
@@ -77,7 +77,7 @@ class ApiKeyListResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class ApiKeyUpdateResponse(BaseModel):
+class ApiKeyUpdateResponse(BaseModel, extra="allow"):
     object: Optional[str]
     total: Optional[int]
     data: Optional[List[Dict[str, Any]]]

--- a/portkey_ai/api_resources/types/api_keys_type.py
+++ b/portkey_ai/api_resources/types/api_keys_type.py
@@ -6,9 +6,9 @@ from portkey_ai.api_resources.types.utils import parse_headers
 
 
 class ApiKeyAddResponse(BaseModel, extra="allow"):
-    id: Optional[str]
-    key: Optional[str]
-    object: Optional[str]
+    id: Optional[str] = None
+    key: Optional[str] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -25,24 +25,24 @@ class ApiKeyAddResponse(BaseModel, extra="allow"):
 
 
 class ApiKeyGetResponse(BaseModel, extra="allow"):
-    id: Optional[str]
-    key: Optional[str]
-    name: Optional[str]
-    description: Optional[str]
-    type: Optional[str]
-    organisation_id: Optional[str]
-    workspace_id: Optional[str]
-    user_id: Optional[str]
-    status: Optional[str]
-    created_at: Optional[str]
-    last_updated_at: Optional[str]
-    creation_mode: Optional[str]
-    rate_limits: Optional[List[Dict[str, Any]]]
-    usage_limits: Optional[Dict[str, Any]]
-    reset_usage: Optional[int]
-    scopes: Optional[List[str]]
-    defaults: Optional[Dict[str, Any]]
-    object: Optional[str]
+    id: Optional[str] = None
+    key: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    type: Optional[str] = None
+    organisation_id: Optional[str] = None
+    workspace_id: Optional[str] = None
+    user_id: Optional[str] = None
+    status: Optional[str] = None
+    created_at: Optional[str] = None
+    last_updated_at: Optional[str] = None
+    creation_mode: Optional[str] = None
+    rate_limits: Optional[List[Dict[str, Any]]] = None
+    usage_limits: Optional[Dict[str, Any]] = None
+    reset_usage: Optional[int] = None
+    scopes: Optional[List[str]] = None
+    defaults: Optional[Dict[str, Any]] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -59,9 +59,9 @@ class ApiKeyGetResponse(BaseModel, extra="allow"):
 
 
 class ApiKeyListResponse(BaseModel, extra="allow"):
-    object: Optional[str]
-    total: Optional[int]
-    data: Optional[List[Dict[str, Any]]]
+    object: Optional[str] = None
+    total: Optional[int] = None
+    data: Optional[List[Dict[str, Any]]] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -78,9 +78,9 @@ class ApiKeyListResponse(BaseModel, extra="allow"):
 
 
 class ApiKeyUpdateResponse(BaseModel, extra="allow"):
-    object: Optional[str]
-    total: Optional[int]
-    data: Optional[List[Dict[str, Any]]]
+    object: Optional[str] = None
+    total: Optional[int] = None
+    data: Optional[List[Dict[str, Any]]] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:

--- a/portkey_ai/api_resources/types/assistant_type.py
+++ b/portkey_ai/api_resources/types/assistant_type.py
@@ -12,8 +12,31 @@ __all__ = [
     "ToolCodeInterpreter",
     "ToolRetrieval",
     "ToolFunction",
-    "Tool",
+    "AssistantTool",
+    "FunctionDefinition",
+    "FunctionParameters",
+    "FileSearch",
+    "FileSearchTool",
 ]
+
+
+class FileSearch(BaseModel, extra="allow"):
+    max_num_results: Optional[int] = None
+
+
+class FileSearchTool(BaseModel, extra="allow"):
+    type: Optional[str] = None
+    file_search: Optional[FileSearch] = None
+
+
+FunctionParameters = Dict[str, object]
+
+
+class FunctionDefinition(BaseModel, extra="allow"):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    parameters: Optional[FunctionParameters] = None
+    strict: Optional[bool] = None
 
 
 class ToolCodeInterpreter(BaseModel, extra="allow"):
@@ -26,9 +49,10 @@ class ToolRetrieval(BaseModel, extra="allow"):
 
 class ToolFunction(BaseModel, extra="allow"):
     type: Optional[str] = None
+    function: Optional[FunctionDefinition] = None
 
 
-Tool = Union[ToolCodeInterpreter, ToolRetrieval, ToolFunction]
+AssistantTool = Union[ToolCodeInterpreter, ToolRetrieval, ToolFunction, FileSearchTool]
 
 
 class Assistant(BaseModel, extra="allow"):
@@ -41,7 +65,8 @@ class Assistant(BaseModel, extra="allow"):
     model: Optional[str] = None
     name: Optional[str] = None
     object: Optional[str] = None
-    tools: Optional[List[Tool]]
+    tools: Optional[List[AssistantTool]] = None
+    response_format: Optional[Any] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):

--- a/portkey_ai/api_resources/types/assistant_type.py
+++ b/portkey_ai/api_resources/types/assistant_type.py
@@ -17,30 +17,30 @@ __all__ = [
 
 
 class ToolCodeInterpreter(BaseModel, extra="allow"):
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 class ToolRetrieval(BaseModel, extra="allow"):
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 class ToolFunction(BaseModel, extra="allow"):
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 Tool = Union[ToolCodeInterpreter, ToolRetrieval, ToolFunction]
 
 
 class Assistant(BaseModel, extra="allow"):
-    id: Optional[str]
-    created_at: Optional[int]
+    id: Optional[str] = None
+    created_at: Optional[int] = None
     description: Optional[str] = None
     file_ids: Optional[List[str]] = None
     instructions: Optional[str] = None
     metadata: Optional[object] = None
-    model: Optional[str]
+    model: Optional[str] = None
     name: Optional[str] = None
-    object: Optional[str]
+    object: Optional[str] = None
     tools: Optional[List[Tool]]
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
@@ -59,7 +59,7 @@ class Assistant(BaseModel, extra="allow"):
 
 
 class AssistantList(BaseModel, extra="allow"):
-    object: Optional[str]
+    object: Optional[str] = None
     data: Optional[List[Assistant]]
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
@@ -78,9 +78,9 @@ class AssistantList(BaseModel, extra="allow"):
 
 
 class AssistantDeleted(BaseModel, extra="allow"):
-    id: Optional[str]
-    object: Optional[str]
-    deleted: Optional[bool]
+    id: Optional[str] = None
+    object: Optional[str] = None
+    deleted: Optional[bool] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):

--- a/portkey_ai/api_resources/types/assistant_type.py
+++ b/portkey_ai/api_resources/types/assistant_type.py
@@ -16,22 +16,22 @@ __all__ = [
 ]
 
 
-class ToolCodeInterpreter(BaseModel):
+class ToolCodeInterpreter(BaseModel, extra="allow"):
     type: Optional[str]
 
 
-class ToolRetrieval(BaseModel):
+class ToolRetrieval(BaseModel, extra="allow"):
     type: Optional[str]
 
 
-class ToolFunction(BaseModel):
+class ToolFunction(BaseModel, extra="allow"):
     type: Optional[str]
 
 
 Tool = Union[ToolCodeInterpreter, ToolRetrieval, ToolFunction]
 
 
-class Assistant(BaseModel):
+class Assistant(BaseModel, extra="allow"):
     id: Optional[str]
     created_at: Optional[int]
     description: Optional[str] = None
@@ -89,48 +89,3 @@ class AssistantDeleted(BaseModel, extra="allow"):
 
     def get_headers(self) -> Optional[Dict[str, str]]:
         return parse_headers(self._headers)
-
-
-# class AssistantFile(BaseModel, extra="allow"):
-#     id: Optional[str]
-#     assistant_id: Optional[str]
-#     created_at: Optional[int]
-#     object: Optional[str]
-#     _headers: Optional[httpx.Headers] = PrivateAttr()
-
-#     def __str__(self):
-#         del self._headers
-#         return json.dumps(self.dict(), indent=4)
-
-#     def get_headers(self) -> Optional[Dict[str, str]]:
-#         return parse_headers(self._headers)
-
-
-# class AssistantFileList(BaseModel, extra="allow"):
-#     object: Optional[str]
-#     data: Optional[List[AssistantFile]]
-#     first_id: Optional[str]
-#     last_id: Optional[str]
-#     has_more: Optional[bool]
-#     _headers: Optional[httpx.Headers] = PrivateAttr()
-
-#     def __str__(self):
-#         del self._headers
-#         return json.dumps(self.dict(), indent=4)
-
-#     def get_headers(self) -> Optional[Dict[str, str]]:
-#         return parse_headers(self._headers)
-
-
-# class AssistantFileDeleted(BaseModel, extra="allow"):
-#     id: Optional[str]
-#     deleted: Optional[bool]
-#     object: Optional[str]
-#     _headers: Optional[httpx.Headers] = PrivateAttr()
-
-#     def __str__(self):
-#         del self._headers
-#         return json.dumps(self.dict(), indent=4)
-
-#     def get_headers(self) -> Optional[Dict[str, str]]:
-#         return parse_headers(self._headers)

--- a/portkey_ai/api_resources/types/audio_types.py
+++ b/portkey_ai/api_resources/types/audio_types.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, PrivateAttr
 __all__ = ["Transcription", "Translation"]
 
 
-class Transcription(BaseModel):
+class Transcription(BaseModel, extra="allow"):
     text: str
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
@@ -26,7 +26,7 @@ class Transcription(BaseModel):
         return parse_headers(self._headers)
 
 
-class Translation(BaseModel):
+class Translation(BaseModel, extra="allow"):
     text: str
     _headers: Optional[httpx.Headers] = PrivateAttr()
 

--- a/portkey_ai/api_resources/types/batches_type.py
+++ b/portkey_ai/api_resources/types/batches_type.py
@@ -5,17 +5,26 @@ import httpx
 from .utils import parse_headers
 from typing import List, Any
 from pydantic import BaseModel, PrivateAttr
-from ..._vendor.openai.types.batch_error import BatchError
-from ..._vendor.openai.types.batch_request_counts import BatchRequestCounts
 
 __all__ = ["Batch", "BatchList", "Errors"]
 
 
+class BatchError(BaseModel, extra="allow"):
+    code: Optional[str] = None
+    line: Optional[int] = None
+    message: Optional[str] = None
+    param: Optional[str] = None
+
+
+class BatchRequestCounts(BaseModel, extra="allow"):
+    completed: Optional[int] = None
+    failed: Optional[int] = None
+    total: Optional[int] = None
+
+
 class Errors(BaseModel, extra="allow"):
     data: Optional[List[BatchError]] = None
-
     object: Optional[str] = None
-    """The object type, which is always `list`."""
 
 
 class Batch(BaseModel, extra="allow"):

--- a/portkey_ai/api_resources/types/batches_type.py
+++ b/portkey_ai/api_resources/types/batches_type.py
@@ -11,14 +11,14 @@ from ..._vendor.openai.types.batch_request_counts import BatchRequestCounts
 __all__ = ["Batch", "BatchList", "Errors"]
 
 
-class Errors(BaseModel):
+class Errors(BaseModel, extra="allow"):
     data: Optional[List[BatchError]] = None
 
     object: Optional[str] = None
     """The object type, which is always `list`."""
 
 
-class Batch(BaseModel):
+class Batch(BaseModel, extra="allow"):
     id: str
     completion_window: str
     created_at: int
@@ -55,7 +55,7 @@ class Batch(BaseModel):
         return parse_headers(self._headers)
 
 
-class BatchList(BaseModel):
+class BatchList(BaseModel, extra="allow"):
     object: Optional[str] = None
     data: Optional[List[Batch]] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()

--- a/portkey_ai/api_resources/types/beta_chat_type.py
+++ b/portkey_ai/api_resources/types/beta_chat_type.py
@@ -1,0 +1,50 @@
+from typing import Optional, TypeVar, List, Any
+import json
+from pydantic import BaseModel
+from .chat_complete_type import (
+    ChatCompletions,
+    Choice,
+    ChatCompletionMessage,
+    ChatCompletionMessageToolCall,
+    FunctionCall,
+)
+
+__all__ = [
+    "ParsedChatCompletion",
+    "ParsedChoice",
+    "ParsedChatCompletionMessage",
+    "ParsedFunction",
+    "ParsedFunctionToolCall",
+]
+
+ContentType = TypeVar("ContentType")
+
+
+class ParsedFunction(FunctionCall, BaseModel, extra="allow"):
+    parsed_arguments: Optional[Any] = None
+
+
+class ParsedFunctionToolCall(ChatCompletionMessageToolCall, BaseModel, extra="allow"):
+    function: ParsedFunction
+
+
+class ParsedChatCompletionMessage(ChatCompletionMessage, BaseModel, extra="allow"):
+    parsed: Optional[Any] = None
+    tool_calls: Optional[List[ParsedFunctionToolCall]] = None  # type: ignore[assignment]
+
+
+class ParsedChoice(Choice, BaseModel, extra="allow"):
+    message: ParsedChatCompletionMessage
+
+
+class ParsedChatCompletion(ChatCompletions, BaseModel, extra="allow"):
+    choices: List[ParsedChoice]  # type: ignore[assignment]
+
+    def __str__(self):
+        return json.dumps(self.dict(), indent=4)
+
+    def __getitem__(self, key):
+        return getattr(self, key, None)
+
+    def get(self, key: str, default: Optional[Any] = None):
+        return getattr(self, key, None) or default

--- a/portkey_ai/api_resources/types/chat_complete_type.py
+++ b/portkey_ai/api_resources/types/chat_complete_type.py
@@ -24,15 +24,15 @@ __all__ = [
 
 
 class TopLogprob(BaseModel, extra="allow"):
-    token: Optional[str]
+    token: Optional[str] = None
     bytes: Optional[List[int]] = None
-    logprob: Optional[float]
+    logprob: Optional[float] = None
 
 
 class ChatCompletionTokenLogprob(BaseModel, extra="allow"):
-    token: Optional[str]
+    token: Optional[str] = None
     bytes: Optional[List[int]] = None
-    logprob: Optional[float]
+    logprob: Optional[float] = None
     top_logprobs: Optional[List[TopLogprob]]
 
 
@@ -53,7 +53,7 @@ class DeltaToolCallFunction(BaseModel, extra="allow"):
 
 
 class DeltaToolCall(BaseModel, extra="allow"):
-    index: Optional[int]
+    index: Optional[int] = None
     id: Optional[str] = None
     function: Optional[DeltaToolCallFunction] = None
     type: Optional[str] = None
@@ -83,37 +83,37 @@ class StreamChoice(BaseModel, extra="allow"):
 
 
 class FunctionCall(BaseModel, extra="allow"):
-    arguments: Optional[str]
-    name: Optional[str]
+    arguments: Optional[str] = None
+    name: Optional[str] = None
 
 
 class ChatCompletionMessageToolCall(BaseModel, extra="allow"):
-    id: Optional[str]
+    id: Optional[str] = None
     function: Optional[FunctionCall]
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 class ChatCompletionMessage(BaseModel, extra="allow"):
     content: Optional[Union[str, Iterable[Any]]] = None
-    role: Optional[str]
+    role: Optional[str] = None
     function_call: Optional[FunctionCall] = None
     tool_calls: Optional[List[ChatCompletionMessageToolCall]] = None
     refusal: Optional[str] = None
 
 
 class Choice(BaseModel, extra="allow"):
-    finish_reason: Optional[str]
-    index: Optional[int]
+    finish_reason: Optional[str] = None
+    index: Optional[int] = None
     logprobs: Optional[ChoiceLogprobs] = None
     message: Optional[ChatCompletionMessage]
 
 
 class ChatCompletions(BaseModel, extra="allow"):
-    id: Optional[str]
+    id: Optional[str] = None
     choices: Optional[List[Choice]]
-    created: Optional[int]
-    model: Optional[str]
-    object: Optional[str]
+    created: Optional[int] = None
+    model: Optional[str] = None
+    object: Optional[str] = None
     system_fingerprint: Optional[str] = None
     usage: Optional[Usage] = None
     service_tier: Optional[str] = None

--- a/portkey_ai/api_resources/types/chat_complete_type.py
+++ b/portkey_ai/api_resources/types/chat_complete_type.py
@@ -98,6 +98,7 @@ class ChatCompletionMessage(BaseModel, extra="allow"):
     role: Optional[str]
     function_call: Optional[FunctionCall] = None
     tool_calls: Optional[List[ChatCompletionMessageToolCall]] = None
+    refusal: Optional[str] = None
 
 
 class Choice(BaseModel, extra="allow"):

--- a/portkey_ai/api_resources/types/complete_type.py
+++ b/portkey_ai/api_resources/types/complete_type.py
@@ -8,27 +8,27 @@ from pydantic import BaseModel, PrivateAttr
 __all__ = ["CompletionUsage", "Logprobs", "CompletionChoice", "TextCompletion"]
 
 
-class CompletionUsage(BaseModel):
+class CompletionUsage(BaseModel, extra="allow"):
     completion_tokens: Optional[int]
     prompt_tokens: Optional[int]
     total_tokens: Optional[int]
 
 
-class Logprobs(BaseModel):
+class Logprobs(BaseModel, extra="allow"):
     text_offset: Optional[List[int]] = None
     token_logprobs: Optional[List[Optional[float]]] = None
     tokens: Optional[List[str]] = None
     top_logprobs: Optional[List[Optional[Dict[str, float]]]] = None
 
 
-class CompletionChoice(BaseModel):
+class CompletionChoice(BaseModel, extra="allow"):
     finish_reason: Optional[str]
     index: Optional[int]
     logprobs: Optional[Logprobs] = None
     text: Optional[str]
 
 
-class TextCompletion(BaseModel):
+class TextCompletion(BaseModel, extra="allow"):
     id: Optional[str]
     choices: List[CompletionChoice]
     created: Optional[int]

--- a/portkey_ai/api_resources/types/complete_type.py
+++ b/portkey_ai/api_resources/types/complete_type.py
@@ -9,9 +9,9 @@ __all__ = ["CompletionUsage", "Logprobs", "CompletionChoice", "TextCompletion"]
 
 
 class CompletionUsage(BaseModel, extra="allow"):
-    completion_tokens: Optional[int]
-    prompt_tokens: Optional[int]
-    total_tokens: Optional[int]
+    completion_tokens: Optional[int] = None
+    prompt_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
 
 
 class Logprobs(BaseModel, extra="allow"):
@@ -22,18 +22,18 @@ class Logprobs(BaseModel, extra="allow"):
 
 
 class CompletionChoice(BaseModel, extra="allow"):
-    finish_reason: Optional[str]
-    index: Optional[int]
+    finish_reason: Optional[str] = None
+    index: Optional[int] = None
     logprobs: Optional[Logprobs] = None
-    text: Optional[str]
+    text: Optional[str] = None
 
 
 class TextCompletion(BaseModel, extra="allow"):
-    id: Optional[str]
+    id: Optional[str] = None
     choices: List[CompletionChoice]
-    created: Optional[int]
-    model: Optional[str]
-    object: Optional[str]
+    created: Optional[int] = None
+    model: Optional[str] = None
+    object: Optional[str] = None
     system_fingerprint: Optional[str] = None
     usage: Optional[CompletionUsage] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()

--- a/portkey_ai/api_resources/types/configs_type.py
+++ b/portkey_ai/api_resources/types/configs_type.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, PrivateAttr
 from portkey_ai.api_resources.types.utils import parse_headers
 
 
-class ConfigAddResponse(BaseModel):
+class ConfigAddResponse(BaseModel, extra="allow"):
     id: Optional[str]
     version_id: Optional[str]
     slug: Optional[str]
@@ -25,7 +25,7 @@ class ConfigAddResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class ConfigGetResponse(BaseModel):
+class ConfigGetResponse(BaseModel, extra="allow"):
     id: Optional[str]
     organisation_id: Optional[str] = None
     config: Optional[Union[str, dict]]
@@ -57,7 +57,7 @@ class ConfigGetResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class ConfigListResponse(BaseModel):
+class ConfigListResponse(BaseModel, extra="allow"):
     object: Optional[str]
     total: Optional[int]
     data: Optional[List[Dict[str, Any]]]
@@ -77,7 +77,7 @@ class ConfigListResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class ConfigUpdateResponse(BaseModel):
+class ConfigUpdateResponse(BaseModel, extra="allow"):
     version_id: Optional[str]
     object: Optional[str]
     _headers: Optional[httpx.Headers] = PrivateAttr()

--- a/portkey_ai/api_resources/types/configs_type.py
+++ b/portkey_ai/api_resources/types/configs_type.py
@@ -6,10 +6,10 @@ from portkey_ai.api_resources.types.utils import parse_headers
 
 
 class ConfigAddResponse(BaseModel, extra="allow"):
-    id: Optional[str]
-    version_id: Optional[str]
-    slug: Optional[str]
-    object: Optional[str]
+    id: Optional[str] = None
+    version_id: Optional[str] = None
+    slug: Optional[str] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -26,22 +26,22 @@ class ConfigAddResponse(BaseModel, extra="allow"):
 
 
 class ConfigGetResponse(BaseModel, extra="allow"):
-    id: Optional[str]
+    id: Optional[str] = None
     organisation_id: Optional[str] = None
-    config: Optional[Union[str, dict]]
-    name: Optional[str]
-    workspace_id: Optional[str]
-    slug: Optional[str]
-    is_default: Optional[int]
-    status: Optional[str]
-    owner_id: Optional[str]
-    created_at: Optional[str]
-    updated_by: Optional[str]
-    last_updated_at: Optional[str]
-    format: Optional[str]
-    type: Optional[str]
-    version_id: Optional[str]
-    object: Optional[str]
+    config: Optional[Union[str, dict]] = None
+    name: Optional[str] = None
+    workspace_id: Optional[str] = None
+    slug: Optional[str] = None
+    is_default: Optional[int] = None
+    status: Optional[str] = None
+    owner_id: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_by: Optional[str] = None
+    last_updated_at: Optional[str] = None
+    format: Optional[str] = None
+    type: Optional[str] = None
+    version_id: Optional[str] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -58,9 +58,9 @@ class ConfigGetResponse(BaseModel, extra="allow"):
 
 
 class ConfigListResponse(BaseModel, extra="allow"):
-    object: Optional[str]
-    total: Optional[int]
-    data: Optional[List[Dict[str, Any]]]
+    object: Optional[str] = None
+    total: Optional[int] = None
+    data: Optional[List[Dict[str, Any]]] = None
 
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
@@ -78,8 +78,8 @@ class ConfigListResponse(BaseModel, extra="allow"):
 
 
 class ConfigUpdateResponse(BaseModel, extra="allow"):
-    version_id: Optional[str]
-    object: Optional[str]
+    version_id: Optional[str] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:

--- a/portkey_ai/api_resources/types/embeddings_type.py
+++ b/portkey_ai/api_resources/types/embeddings_type.py
@@ -15,13 +15,13 @@ class Usage(BaseModel, extra="allow"):
     total_tokens: Optional[int] = None
 
 
-class Embedding(BaseModel):
+class Embedding(BaseModel, extra="allow"):
     embedding: Union[List[float], str]
     index: Optional[int]
     object: Optional[str]
 
 
-class CreateEmbeddingResponse(BaseModel):
+class CreateEmbeddingResponse(BaseModel, extra="allow"):
     success: Optional[bool] = None
     warning: Optional[str] = None
     data: List[Embedding]

--- a/portkey_ai/api_resources/types/embeddings_type.py
+++ b/portkey_ai/api_resources/types/embeddings_type.py
@@ -17,16 +17,16 @@ class Usage(BaseModel, extra="allow"):
 
 class Embedding(BaseModel, extra="allow"):
     embedding: Union[List[float], str]
-    index: Optional[int]
-    object: Optional[str]
+    index: Optional[int] = None
+    object: Optional[str] = None
 
 
 class CreateEmbeddingResponse(BaseModel, extra="allow"):
     success: Optional[bool] = None
     warning: Optional[str] = None
     data: List[Embedding]
-    model: Optional[str]
-    object: Optional[str]
+    model: Optional[str] = None
+    object: Optional[str] = None
     usage: Usage
     _headers: Optional[httpx.Headers] = PrivateAttr()
 

--- a/portkey_ai/api_resources/types/feedback_type.py
+++ b/portkey_ai/api_resources/types/feedback_type.py
@@ -5,6 +5,6 @@ from pydantic import BaseModel
 
 
 class FeedbackResponse(BaseModel, extra="allow"):
-    status: Optional[str]
-    message: Optional[str]
-    feedback_ids: Optional[List[str]]
+    status: Optional[str] = None
+    message: Optional[str] = None
+    feedback_ids: Optional[List[str]] = None

--- a/portkey_ai/api_resources/types/feedback_type.py
+++ b/portkey_ai/api_resources/types/feedback_type.py
@@ -4,7 +4,7 @@ from typing import List
 from pydantic import BaseModel
 
 
-class FeedbackResponse(BaseModel):
+class FeedbackResponse(BaseModel, extra="allow"):
     status: Optional[str]
     message: Optional[str]
     feedback_ids: Optional[List[str]]

--- a/portkey_ai/api_resources/types/fine_tuning_type.py
+++ b/portkey_ai/api_resources/types/fine_tuning_type.py
@@ -4,7 +4,6 @@ import httpx
 from .utils import parse_headers
 from typing import List, Any
 from pydantic import BaseModel, PrivateAttr
-from ..._vendor.openai.types.fine_tuning import FineTuningJobWandbIntegrationObject
 
 __all__ = [
     "Error",
@@ -16,6 +15,8 @@ __all__ = [
     "Metrics",
     "FineTuningJobCheckpoint",
     "FineTuningJobCheckpointList",
+    "FineTuningJobWandbIntegration",
+    "FineTuningJobWandbIntegrationObject",
 ]
 
 
@@ -27,6 +28,18 @@ class Error(BaseModel, extra="allow"):
 
 class Hyperparameters(BaseModel, extra="allow"):
     n_epochs: Union[str, int]
+
+
+class FineTuningJobWandbIntegration(BaseModel, extra="allow"):
+    project: str
+    entity: Optional[str] = None
+    name: Optional[str] = None
+    tags: Optional[List[str]] = None
+
+
+class FineTuningJobWandbIntegrationObject(BaseModel, extra="allow"):
+    type: Optional[str] = None
+    wandb: FineTuningJobWandbIntegration
 
 
 class FineTuningJob(BaseModel, extra="allow"):

--- a/portkey_ai/api_resources/types/fine_tuning_type.py
+++ b/portkey_ai/api_resources/types/fine_tuning_type.py
@@ -19,17 +19,17 @@ __all__ = [
 ]
 
 
-class Error(BaseModel):
+class Error(BaseModel, extra="allow"):
     code: str
     message: str
     param: Optional[str] = None
 
 
-class Hyperparameters(BaseModel):
+class Hyperparameters(BaseModel, extra="allow"):
     n_epochs: Union[str, int]
 
 
-class FineTuningJob(BaseModel):
+class FineTuningJob(BaseModel, extra="allow"):
     id: str
     created_at: int
     error: Optional[Error] = None
@@ -63,7 +63,7 @@ class FineTuningJob(BaseModel):
         return parse_headers(self._headers)
 
 
-class FineTuningJobList(BaseModel):
+class FineTuningJobList(BaseModel, extra="allow"):
     object: Optional[str] = None
     data: Optional[List[FineTuningJob]] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
@@ -82,7 +82,7 @@ class FineTuningJobList(BaseModel):
         return parse_headers(self._headers)
 
 
-class FineTuningJobEvent(BaseModel):
+class FineTuningJobEvent(BaseModel, extra="allow"):
     id: str
     created_at: int
     level: str
@@ -104,7 +104,7 @@ class FineTuningJobEvent(BaseModel):
         return parse_headers(self._headers)
 
 
-class FineTuningJobEventList(BaseModel):
+class FineTuningJobEventList(BaseModel, extra="allow"):
     object: Optional[str] = None
     data: Optional[List[FineTuningJobEvent]] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
@@ -123,7 +123,7 @@ class FineTuningJobEventList(BaseModel):
         return parse_headers(self._headers)
 
 
-class Metrics(BaseModel):
+class Metrics(BaseModel, extra="allow"):
     full_valid_loss: Optional[float] = None
     full_valid_mean_token_accuracy: Optional[float] = None
     step: Optional[float] = None
@@ -133,7 +133,7 @@ class Metrics(BaseModel):
     valid_mean_token_accuracy: Optional[float] = None
 
 
-class FineTuningJobCheckpoint(BaseModel):
+class FineTuningJobCheckpoint(BaseModel, extra="allow"):
     id: str
     created_at: int
     fine_tuned_model_checkpoint: str
@@ -157,7 +157,7 @@ class FineTuningJobCheckpoint(BaseModel):
         return parse_headers(self._headers)
 
 
-class FineTuningJobCheckpointList(BaseModel):
+class FineTuningJobCheckpointList(BaseModel, extra="allow"):
     object: Optional[str] = None
     data: Optional[List[FineTuningJobCheckpoint]] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()

--- a/portkey_ai/api_resources/types/generation_type.py
+++ b/portkey_ai/api_resources/types/generation_type.py
@@ -64,14 +64,14 @@ FunctionParameters = Dict[str, object]
 
 
 class Function(BaseModel, extra="allow"):
-    name: Optional[str]
+    name: Optional[str] = None
     description: Optional[str] = None
     parameters: Optional[FunctionParameters] = None
 
 
 class Tool(BaseModel, extra="allow"):
     function: Function
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 class PromptRenderData(BaseModel, extra="allow"):

--- a/portkey_ai/api_resources/types/generation_type.py
+++ b/portkey_ai/api_resources/types/generation_type.py
@@ -15,7 +15,7 @@ from typing import List, Any
 from pydantic import BaseModel, PrivateAttr
 
 
-class PromptCompletion(BaseModel):
+class PromptCompletion(BaseModel, extra="allow"):
     id: Optional[str] = None
     choices: Optional[List[Choice]] = None
     created: Optional[int] = None
@@ -42,7 +42,7 @@ class PromptCompletion(BaseModel):
         return parse_headers(self._headers)
 
 
-class PromptCompletionChunk(BaseModel):
+class PromptCompletionChunk(BaseModel, extra="allow"):
     id: Optional[str] = None
     object: Optional[str] = None
     created: Optional[int] = None
@@ -63,18 +63,18 @@ class PromptCompletionChunk(BaseModel):
 FunctionParameters = Dict[str, object]
 
 
-class Function(BaseModel):
+class Function(BaseModel, extra="allow"):
     name: Optional[str]
     description: Optional[str] = None
     parameters: Optional[FunctionParameters] = None
 
 
-class Tool(BaseModel):
+class Tool(BaseModel, extra="allow"):
     function: Function
     type: Optional[str]
 
 
-class PromptRenderData(BaseModel):
+class PromptRenderData(BaseModel, extra="allow"):
     messages: Optional[List[ChatCompletionMessage]] = None
     prompt: Optional[str] = None
     model: Optional[str] = None
@@ -102,7 +102,7 @@ class PromptRenderData(BaseModel):
     tools: Optional[List[Tool]] = None
 
 
-class PromptRender(BaseModel):
+class PromptRender(BaseModel, extra="allow"):
     success: Optional[bool] = True
     data: PromptRenderData
 

--- a/portkey_ai/api_resources/types/image_type.py
+++ b/portkey_ai/api_resources/types/image_type.py
@@ -8,13 +8,13 @@ from pydantic import BaseModel, PrivateAttr
 __all__ = ["ImagesResponse", "Image"]
 
 
-class Image(BaseModel):
+class Image(BaseModel, extra="allow"):
     b64_json: Optional[str] = None
     revised_prompt: Optional[str] = None
     url: Optional[str] = None
 
 
-class ImagesResponse(BaseModel):
+class ImagesResponse(BaseModel, extra="allow"):
     created: Optional[int]
     data: List[Image]
     _headers: Optional[httpx.Headers] = PrivateAttr()

--- a/portkey_ai/api_resources/types/image_type.py
+++ b/portkey_ai/api_resources/types/image_type.py
@@ -15,7 +15,7 @@ class Image(BaseModel, extra="allow"):
 
 
 class ImagesResponse(BaseModel, extra="allow"):
-    created: Optional[int]
+    created: Optional[int] = None
     data: List[Image]
     _headers: Optional[httpx.Headers] = PrivateAttr()
 

--- a/portkey_ai/api_resources/types/logs_type.py
+++ b/portkey_ai/api_resources/types/logs_type.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, PrivateAttr
 from portkey_ai.api_resources.types.utils import parse_headers
 
 
-class LogsExportCreateResponse(BaseModel):
+class LogsExportCreateResponse(BaseModel, extra="allow"):
     id: Optional[str]
     total: Optional[int]
     object: Optional[str]
@@ -24,7 +24,7 @@ class LogsExportCreateResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class LogsExportListResponse(BaseModel):
+class LogsExportListResponse(BaseModel, extra="allow"):
     object: Optional[str]
     total: Optional[int]
     data: Optional[List[Dict[str, Any]]]
@@ -43,7 +43,7 @@ class LogsExportListResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class LogsExportUpdateResponse(BaseModel):
+class LogsExportUpdateResponse(BaseModel, extra="allow"):
     id: Optional[str]
     total: Optional[int]
     object: Optional[str]
@@ -62,7 +62,7 @@ class LogsExportUpdateResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class LogsExportCancelResponse(BaseModel):
+class LogsExportCancelResponse(BaseModel, extra="allow"):
     message: Optional[str]
     object: Optional[str]
     _headers: Optional[httpx.Headers] = PrivateAttr()
@@ -80,7 +80,7 @@ class LogsExportCancelResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class LogsExportRetrieveResponse(BaseModel):
+class LogsExportRetrieveResponse(BaseModel, extra="allow"):
     id: Optional[str]
     organisation_id: Optional[str]
     filters: Optional[Dict[str, Any]]
@@ -108,7 +108,7 @@ class LogsExportRetrieveResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class LogsExportStartResponse(BaseModel):
+class LogsExportStartResponse(BaseModel, extra="allow"):
     message: Optional[str]
     object: Optional[str]
     _headers: Optional[httpx.Headers] = PrivateAttr()
@@ -126,7 +126,7 @@ class LogsExportStartResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class LogsExportDownloadResponse(BaseModel):
+class LogsExportDownloadResponse(BaseModel, extra="allow"):
     signed_url: Optional[str]
     _headers: Optional[httpx.Headers] = PrivateAttr()
 

--- a/portkey_ai/api_resources/types/logs_type.py
+++ b/portkey_ai/api_resources/types/logs_type.py
@@ -6,9 +6,9 @@ from portkey_ai.api_resources.types.utils import parse_headers
 
 
 class LogsExportCreateResponse(BaseModel, extra="allow"):
-    id: Optional[str]
-    total: Optional[int]
-    object: Optional[str]
+    id: Optional[str] = None
+    total: Optional[int] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -25,9 +25,9 @@ class LogsExportCreateResponse(BaseModel, extra="allow"):
 
 
 class LogsExportListResponse(BaseModel, extra="allow"):
-    object: Optional[str]
-    total: Optional[int]
-    data: Optional[List[Dict[str, Any]]]
+    object: Optional[str] = None
+    total: Optional[int] = None
+    data: Optional[List[Dict[str, Any]]] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -44,9 +44,9 @@ class LogsExportListResponse(BaseModel, extra="allow"):
 
 
 class LogsExportUpdateResponse(BaseModel, extra="allow"):
-    id: Optional[str]
-    total: Optional[int]
-    object: Optional[str]
+    id: Optional[str] = None
+    total: Optional[int] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -63,8 +63,8 @@ class LogsExportUpdateResponse(BaseModel, extra="allow"):
 
 
 class LogsExportCancelResponse(BaseModel, extra="allow"):
-    message: Optional[str]
-    object: Optional[str]
+    message: Optional[str] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -81,18 +81,18 @@ class LogsExportCancelResponse(BaseModel, extra="allow"):
 
 
 class LogsExportRetrieveResponse(BaseModel, extra="allow"):
-    id: Optional[str]
-    organisation_id: Optional[str]
-    filters: Optional[Dict[str, Any]]
-    requested_data: Optional[List[str]]
-    status: Optional[str]
-    description: Optional[str]
-    created_at: Optional[str]
-    last_updated_at: Optional[str]
-    created_by: Optional[str]
-    workspace_id: Optional[str]
-    total_records: Optional[int]
-    object: Optional[str]
+    id: Optional[str] = None
+    organisation_id: Optional[str] = None
+    filters: Optional[Dict[str, Any]] = None
+    requested_data: Optional[List[str]] = None
+    status: Optional[str] = None
+    description: Optional[str] = None
+    created_at: Optional[str] = None
+    last_updated_at: Optional[str] = None
+    created_by: Optional[str] = None
+    workspace_id: Optional[str] = None
+    total_records: Optional[int] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -109,8 +109,8 @@ class LogsExportRetrieveResponse(BaseModel, extra="allow"):
 
 
 class LogsExportStartResponse(BaseModel, extra="allow"):
-    message: Optional[str]
-    object: Optional[str]
+    message: Optional[str] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -127,7 +127,7 @@ class LogsExportStartResponse(BaseModel, extra="allow"):
 
 
 class LogsExportDownloadResponse(BaseModel, extra="allow"):
-    signed_url: Optional[str]
+    signed_url: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:

--- a/portkey_ai/api_resources/types/main_file_type.py
+++ b/portkey_ai/api_resources/types/main_file_type.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, PrivateAttr
 __all__ = ["FileObject", "FileList", "FileDeleted"]
 
 
-class FileObject(BaseModel):
+class FileObject(BaseModel, extra="allow"):
     id: Optional[str]
     bytes: Optional[int]
     created_at: Optional[int]
@@ -33,7 +33,7 @@ class FileObject(BaseModel):
         return parse_headers(self._headers)
 
 
-class FileList(BaseModel):
+class FileList(BaseModel, extra="allow"):
     object: Optional[str]
     data: List[FileObject]
     _headers: Optional[httpx.Headers] = PrivateAttr()
@@ -52,7 +52,7 @@ class FileList(BaseModel):
         return parse_headers(self._headers)
 
 
-class FileDeleted(BaseModel):
+class FileDeleted(BaseModel, extra="allow"):
     id: Optional[str]
     deleted: Optional[bool]
     object: Optional[str]

--- a/portkey_ai/api_resources/types/main_file_type.py
+++ b/portkey_ai/api_resources/types/main_file_type.py
@@ -9,13 +9,13 @@ __all__ = ["FileObject", "FileList", "FileDeleted"]
 
 
 class FileObject(BaseModel, extra="allow"):
-    id: Optional[str]
-    bytes: Optional[int]
-    created_at: Optional[int]
-    filename: Optional[str]
-    object: Optional[str]
-    purpose: Optional[str]
-    status: Optional[str]
+    id: Optional[str] = None
+    bytes: Optional[int] = None
+    created_at: Optional[int] = None
+    filename: Optional[str] = None
+    object: Optional[str] = None
+    purpose: Optional[str] = None
+    status: Optional[str] = None
     status_details: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
@@ -34,7 +34,7 @@ class FileObject(BaseModel, extra="allow"):
 
 
 class FileList(BaseModel, extra="allow"):
-    object: Optional[str]
+    object: Optional[str] = None
     data: List[FileObject]
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
@@ -53,9 +53,9 @@ class FileList(BaseModel, extra="allow"):
 
 
 class FileDeleted(BaseModel, extra="allow"):
-    id: Optional[str]
-    deleted: Optional[bool]
-    object: Optional[str]
+    id: Optional[str] = None
+    deleted: Optional[bool] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):

--- a/portkey_ai/api_resources/types/models_type.py
+++ b/portkey_ai/api_resources/types/models_type.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, PrivateAttr
 __all__ = ["Model", "ModelDeleted", "ModelList"]
 
 
-class Model(BaseModel):
+class Model(BaseModel, extra="allow"):
     id: Optional[str]
     created: Optional[int]
     object: Optional[str]
@@ -42,7 +42,7 @@ class ModelList(BaseModel, extra="allow"):
         return parse_headers(self._headers)
 
 
-class ModelDeleted(BaseModel):
+class ModelDeleted(BaseModel, extra="allow"):
     id: Optional[str]
     deleted: Optional[bool]
     object: Optional[str]

--- a/portkey_ai/api_resources/types/models_type.py
+++ b/portkey_ai/api_resources/types/models_type.py
@@ -9,10 +9,10 @@ __all__ = ["Model", "ModelDeleted", "ModelList"]
 
 
 class Model(BaseModel, extra="allow"):
-    id: Optional[str]
-    created: Optional[int]
-    object: Optional[str]
-    owned_by: Optional[str]
+    id: Optional[str] = None
+    created: Optional[int] = None
+    object: Optional[str] = None
+    owned_by: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
@@ -30,7 +30,7 @@ class Model(BaseModel, extra="allow"):
 
 
 class ModelList(BaseModel, extra="allow"):
-    object: Optional[str]
+    object: Optional[str] = None
     data: List[Model]
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
@@ -43,9 +43,9 @@ class ModelList(BaseModel, extra="allow"):
 
 
 class ModelDeleted(BaseModel, extra="allow"):
-    id: Optional[str]
-    deleted: Optional[bool]
-    object: Optional[str]
+    id: Optional[str] = None
+    deleted: Optional[bool] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):

--- a/portkey_ai/api_resources/types/moderations_type.py
+++ b/portkey_ai/api_resources/types/moderations_type.py
@@ -10,7 +10,7 @@ from ..._vendor.openai.types.moderation import Moderation
 __all__ = ["ModerationCreateResponse"]
 
 
-class ModerationCreateResponse(BaseModel):
+class ModerationCreateResponse(BaseModel, extra="allow"):
     id: str
     model: str
     results: List[Moderation]

--- a/portkey_ai/api_resources/types/thread_message_type.py
+++ b/portkey_ai/api_resources/types/thread_message_type.py
@@ -1,6 +1,8 @@
 import json
 from typing import Dict, List, Optional, Union
 import httpx
+
+from portkey_ai.api_resources.types.assistant_type import ToolCodeInterpreter
 from .utils import parse_headers
 from pydantic import BaseModel, PrivateAttr
 
@@ -17,32 +19,58 @@ __all__ = [
     "MessageContentImageFile",
     "ImageFile",
     "MessageContentText",
+    "Attachment",
+    "AttachmentTool",
+    "AttachmentToolAssistantToolsFileSearchTypeOnly",
+    "IncompleteDetails",
+    "ThreadMessageDeleted",
+    "RefusalContentBlock",
+    "ImageURL",
+    "ImageURLContentBlock",
 ]
 
 
+class IncompleteDetails(BaseModel, extra="allow"):
+    reason: Optional[str] = None
+
+
+class AttachmentToolAssistantToolsFileSearchTypeOnly(BaseModel, extra="allow"):
+    type: Optional[str] = None
+
+
+AttachmentTool = Union[
+    ToolCodeInterpreter, AttachmentToolAssistantToolsFileSearchTypeOnly
+]
+
+
+class Attachment(BaseModel, extra="allow"):
+    file_id: Optional[str] = None
+    tools: Optional[List[AttachmentTool]] = None
+
+
 class TextAnnotationFilePathFilePath(BaseModel, extra="allow"):
-    file_id: Optional[str]
+    file_id: Optional[str] = None
 
 
 class TextAnnotationFileCitationFileCitation(BaseModel, extra="allow"):
-    file_id: Optional[str]
-    quote: Optional[str]
+    file_id: Optional[str] = None
+    quote: Optional[str] = None
 
 
 class TextAnnotationFilePath(BaseModel, extra="allow"):
-    end_index: Optional[int]
+    end_index: Optional[int] = None
     file_path: Optional[TextAnnotationFilePathFilePath]
-    start_index: Optional[int]
-    text: Optional[str]
-    type: Optional[str]
+    start_index: Optional[int] = None
+    text: Optional[str] = None
+    type: Optional[str] = None
 
 
 class TextAnnotationFileCitation(BaseModel, extra="allow"):
-    end_index: Optional[int]
+    end_index: Optional[int] = None
     file_citation: Optional[TextAnnotationFileCitationFileCitation]
-    start_index: Optional[int]
-    text: Optional[str]
-    type: Optional[str]
+    start_index: Optional[int] = None
+    text: Optional[str] = None
+    type: Optional[str] = None
 
 
 TextAnnotation = Union[TextAnnotationFileCitation, TextAnnotationFilePath]
@@ -50,37 +78,65 @@ TextAnnotation = Union[TextAnnotationFileCitation, TextAnnotationFilePath]
 
 class Text(BaseModel, extra="allow"):
     annotations: Optional[List[TextAnnotation]]
-    value: Optional[str]
+    value: Optional[str] = None
+
+
+class RefusalContentBlock(BaseModel, extra="allow"):
+    refusal: Optional[str] = None
+
+    type: Optional[str] = None
+
+
+class ImageURL(BaseModel, extra="allow"):
+    url: Optional[str] = None
+    detail: Optional[str] = None
+
+
+class ImageURLContentBlock(BaseModel, extra="allow"):
+    image_url: ImageURL
+
+    type: Optional[str] = None
 
 
 class MessageContentText(BaseModel, extra="allow"):
     text: Optional[Text]
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 class ImageFile(BaseModel, extra="allow"):
-    file_id: Optional[str]
+    file_id: Optional[str] = None
 
 
 class MessageContentImageFile(BaseModel, extra="allow"):
     image_file: Optional[ImageFile]
-    type: Optional[str]
+    type: Optional[str] = None
 
 
-Content = Union[MessageContentImageFile, MessageContentText]
+Content = Union[
+    MessageContentImageFile,
+    ImageURLContentBlock,
+    MessageContentText,
+    RefusalContentBlock,
+]
 
 
 class ThreadMessage(BaseModel, extra="allow"):
-    id: Optional[str]
+    id: Optional[str] = None
     assistant_id: Optional[str] = None
     content: Optional[List[Content]]
-    created_at: Optional[int]
+    created_at: Optional[int] = None
     file_ids: Optional[List[str]] = None
     metadata: Optional[object] = None
-    object: Optional[str]
-    role: Optional[str]
+    object: Optional[str] = None
+    role: Optional[str] = None
     run_id: Optional[str] = None
-    thread_id: Optional[str]
+    thread_id: Optional[str] = None
+    attachments: Optional[List[Attachment]] = None
+    incomplete_at: Optional[int] = None
+    incomplete_details: Optional[IncompleteDetails] = None
+    completed_at: Optional[int] = None
+    status: Optional[str] = None
+
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
@@ -92,11 +148,11 @@ class ThreadMessage(BaseModel, extra="allow"):
 
 
 class MessageList(BaseModel, extra="allow"):
-    object: Optional[str]
+    object: Optional[str] = None
     data: Optional[List[ThreadMessage]]
-    first_id: Optional[str]
-    last_id: Optional[str]
-    has_more: Optional[bool]
+    first_id: Optional[str] = None
+    last_id: Optional[str] = None
+    has_more: Optional[bool] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
@@ -108,9 +164,9 @@ class MessageList(BaseModel, extra="allow"):
 
 
 class ThreadMessageDeleted(BaseModel, extra="allow"):
-    id: str
-    deleted: bool
-    object: str
+    id: Optional[str] = None
+    deleted: Optional[bool] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):

--- a/portkey_ai/api_resources/types/thread_message_type.py
+++ b/portkey_ai/api_resources/types/thread_message_type.py
@@ -20,16 +20,16 @@ __all__ = [
 ]
 
 
-class TextAnnotationFilePathFilePath(BaseModel):
+class TextAnnotationFilePathFilePath(BaseModel, extra="allow"):
     file_id: Optional[str]
 
 
-class TextAnnotationFileCitationFileCitation(BaseModel):
+class TextAnnotationFileCitationFileCitation(BaseModel, extra="allow"):
     file_id: Optional[str]
     quote: Optional[str]
 
 
-class TextAnnotationFilePath(BaseModel):
+class TextAnnotationFilePath(BaseModel, extra="allow"):
     end_index: Optional[int]
     file_path: Optional[TextAnnotationFilePathFilePath]
     start_index: Optional[int]
@@ -37,7 +37,7 @@ class TextAnnotationFilePath(BaseModel):
     type: Optional[str]
 
 
-class TextAnnotationFileCitation(BaseModel):
+class TextAnnotationFileCitation(BaseModel, extra="allow"):
     end_index: Optional[int]
     file_citation: Optional[TextAnnotationFileCitationFileCitation]
     start_index: Optional[int]
@@ -48,21 +48,21 @@ class TextAnnotationFileCitation(BaseModel):
 TextAnnotation = Union[TextAnnotationFileCitation, TextAnnotationFilePath]
 
 
-class Text(BaseModel):
+class Text(BaseModel, extra="allow"):
     annotations: Optional[List[TextAnnotation]]
     value: Optional[str]
 
 
-class MessageContentText(BaseModel):
+class MessageContentText(BaseModel, extra="allow"):
     text: Optional[Text]
     type: Optional[str]
 
 
-class ImageFile(BaseModel):
+class ImageFile(BaseModel, extra="allow"):
     file_id: Optional[str]
 
 
-class MessageContentImageFile(BaseModel):
+class MessageContentImageFile(BaseModel, extra="allow"):
     image_file: Optional[ImageFile]
     type: Optional[str]
 
@@ -107,7 +107,7 @@ class MessageList(BaseModel, extra="allow"):
         return parse_headers(self._headers)
 
 
-class ThreadMessageDeleted(BaseModel):
+class ThreadMessageDeleted(BaseModel, extra="allow"):
     id: str
     deleted: bool
     object: str

--- a/portkey_ai/api_resources/types/thread_run_type.py
+++ b/portkey_ai/api_resources/types/thread_run_type.py
@@ -1,6 +1,8 @@
 import json
 from typing import Dict, Literal, Optional, Union
 import httpx
+
+from portkey_ai.api_resources.types.assistant_type import AssistantTool
 from .utils import parse_headers
 from typing import List
 from pydantic import BaseModel, PrivateAttr
@@ -35,6 +37,11 @@ __all__ = [
     "FunctionToolCall",
     "FunctionParameters",
     "RunStepList",
+    "IncompleteDetails",
+    "AssistantToolChoice",
+    "AssistantToolChoiceFunction",
+    "AssistantToolChoiceOption",
+    "TruncationStrategy",
 ]
 
 
@@ -163,6 +170,28 @@ Tool = Union[
 ]
 
 
+class IncompleteDetails(BaseModel, extra="allow"):
+    reason: Optional[str] = None
+
+
+class AssistantToolChoiceFunction(BaseModel, extra="allow"):
+    name: Optional[str] = None
+
+
+class AssistantToolChoice(BaseModel, extra="allow"):
+    type: Optional[str] = None
+
+    function: Optional[AssistantToolChoiceFunction] = None
+
+
+AssistantToolChoiceOption = Union[Optional[str], AssistantToolChoice]
+
+
+class TruncationStrategy(BaseModel, extra="allow"):
+    type: Optional[str] = None
+    last_messages: Optional[int] = None
+
+
 class Run(BaseModel, extra="allow"):
     id: Optional[str] = None
     assistant_id: Optional[str] = None
@@ -181,8 +210,16 @@ class Run(BaseModel, extra="allow"):
     started_at: Optional[int] = None
     status: Optional[str] = None
     thread_id: Optional[str] = None
-    tools: Optional[List[Tool]]
+    tools: Optional[List[AssistantTool]]
     usage: Optional[Usage] = None
+    incomplete_details: Optional[IncompleteDetails] = None
+    max_completion_tokens: Optional[int] = None
+    max_prompt_tokens: Optional[int] = None
+    parallel_tool_calls: Optional[bool] = None
+    tool_choice: Optional[AssistantToolChoiceOption] = None
+    truncation_strategy: Optional[TruncationStrategy] = None
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):

--- a/portkey_ai/api_resources/types/thread_run_type.py
+++ b/portkey_ai/api_resources/types/thread_run_type.py
@@ -39,49 +39,49 @@ __all__ = [
 
 
 class Function(BaseModel, extra="allow"):
-    arguments: Optional[str]
-    name: Optional[str]
+    arguments: Optional[str] = None
+    name: Optional[str] = None
     output: Optional[str] = None
 
 
 class FunctionToolCall(BaseModel, extra="allow"):
-    id: Optional[str]
+    id: Optional[str] = None
     function: Function
     type: Literal["function"]
 
 
 class RetrievalToolCall(BaseModel, extra="allow"):
-    id: Optional[str]
+    id: Optional[str] = None
     retrieval: Optional[object]
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 class CodeInterpreterOutputLogs(BaseModel, extra="allow"):
-    logs: Optional[str]
-    type: Optional[str]
+    logs: Optional[str] = None
+    type: Optional[str] = None
 
 
 class CodeInterpreterOutputImageImage(BaseModel, extra="allow"):
-    file_id: Optional[str]
+    file_id: Optional[str] = None
 
 
 class CodeInterpreterOutputImage(BaseModel, extra="allow"):
     image: CodeInterpreterOutputImageImage
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 CodeInterpreterOutput = Union[CodeInterpreterOutputLogs, CodeInterpreterOutputImage]
 
 
 class CodeInterpreter(BaseModel, extra="allow"):
-    input: Optional[str]
+    input: Optional[str] = None
     outputs: List[CodeInterpreterOutput]
 
 
 class CodeToolCall(BaseModel, extra="allow"):
-    id: Optional[str]
+    id: Optional[str] = None
     code_interpreter: CodeInterpreter
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 ToolCall = Union[CodeToolCall, RetrievalToolCall, FunctionToolCall]
@@ -89,42 +89,42 @@ ToolCall = Union[CodeToolCall, RetrievalToolCall, FunctionToolCall]
 
 class ToolCallsStepDetails(BaseModel, extra="allow"):
     tool_calls: Optional[List[ToolCall]]
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 class MessageCreation(BaseModel, extra="allow"):
-    message_id: Optional[str]
+    message_id: Optional[str] = None
 
 
 class MessageCreationStepDetails(BaseModel, extra="allow"):
     message_creation: Optional[MessageCreation]
 
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 StepDetails = Union[MessageCreationStepDetails, ToolCallsStepDetails]
 
 
 class Usage(BaseModel, extra="allow"):
-    completion_tokens: Optional[int]
-    prompt_tokens: Optional[int]
-    total_tokens: Optional[int]
+    completion_tokens: Optional[int] = None
+    prompt_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
 
 
 class LastError(BaseModel, extra="allow"):
-    code: Optional[str]
-    message: Optional[str]
+    code: Optional[str] = None
+    message: Optional[str] = None
 
 
 class FunctionRA(BaseModel, extra="allow"):
-    arguments: Optional[str]
-    name: Optional[str]
+    arguments: Optional[str] = None
+    name: Optional[str] = None
 
 
 class RequiredActionFunctionToolCall(BaseModel, extra="allow"):
-    id: Optional[str]
+    id: Optional[str] = None
     function: Optional[FunctionRA]
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 class RequiredActionSubmitToolOutputs(BaseModel, extra="allow"):
@@ -133,29 +133,29 @@ class RequiredActionSubmitToolOutputs(BaseModel, extra="allow"):
 
 class RequiredAction(BaseModel, extra="allow"):
     submit_tool_outputs: Optional[RequiredActionSubmitToolOutputs]
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 FunctionParameters = Dict[str, object]
 
 
 class FunctionDefinition(BaseModel, extra="allow"):
-    name: Optional[str]
+    name: Optional[str] = None
     description: Optional[str] = None
     parameters: Optional[FunctionParameters] = None
 
 
 class ToolAssistantToolsCode(BaseModel, extra="allow"):
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 class ToolAssistantToolsRetrieval(BaseModel, extra="allow"):
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 class ToolAssistantToolsFunction(BaseModel, extra="allow"):
     function: Optional[FunctionDefinition]
-    type: Optional[str]
+    type: Optional[str] = None
 
 
 Tool = Union[
@@ -164,23 +164,23 @@ Tool = Union[
 
 
 class Run(BaseModel, extra="allow"):
-    id: Optional[str]
-    assistant_id: Optional[str]
+    id: Optional[str] = None
+    assistant_id: Optional[str] = None
     cancelled_at: Optional[int] = None
     completed_at: Optional[int] = None
-    created_at: Optional[int]
-    expires_at: Optional[int]
+    created_at: Optional[int] = None
+    expires_at: Optional[int] = None
     failed_at: Optional[int] = None
     file_ids: Optional[List[str]] = None
-    instructions: Optional[str]
+    instructions: Optional[str] = None
     last_error: Optional[LastError] = None
     metadata: Optional[object] = None
-    model: Optional[str]
-    object: Optional[str]
+    model: Optional[str] = None
+    object: Optional[str] = None
     required_action: Optional[RequiredAction] = None
     started_at: Optional[int] = None
-    status: Optional[str]
-    thread_id: Optional[str]
+    status: Optional[str] = None
+    thread_id: Optional[str] = None
     tools: Optional[List[Tool]]
     usage: Optional[Usage] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
@@ -194,11 +194,11 @@ class Run(BaseModel, extra="allow"):
 
 
 class RunList(BaseModel, extra="allow"):
-    object: Optional[str]
+    object: Optional[str] = None
     data: Optional[List[Run]]
-    first_id: Optional[str]
-    last_id: Optional[str]
-    has_more: Optional[bool]
+    first_id: Optional[str] = None
+    last_id: Optional[str] = None
+    has_more: Optional[bool] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
@@ -210,21 +210,21 @@ class RunList(BaseModel, extra="allow"):
 
 
 class RunStep(BaseModel, extra="allow"):
-    id: Optional[str]
-    assistant_id: Optional[str]
+    id: Optional[str] = None
+    assistant_id: Optional[str] = None
     cancelled_at: Optional[int] = None
     completed_at: Optional[int] = None
-    created_at: Optional[int]
+    created_at: Optional[int] = None
     expired_at: Optional[int] = None
     failed_at: Optional[int] = None
     last_error: Optional[LastError] = None
     metadata: Optional[object] = None
-    object: Optional[str]
-    run_id: Optional[str]
-    status: Optional[str]
+    object: Optional[str] = None
+    run_id: Optional[str] = None
+    status: Optional[str] = None
     step_details: Optional[StepDetails]
-    thread_id: Optional[str]
-    type: Optional[str]
+    thread_id: Optional[str] = None
+    type: Optional[str] = None
     usage: Optional[Usage] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
@@ -237,11 +237,11 @@ class RunStep(BaseModel, extra="allow"):
 
 
 class RunStepList(BaseModel, extra="allow"):
-    object: Optional[str]
+    object: Optional[str] = None
     data: Optional[List[RunStep]]
-    first_id: Optional[str]
-    last_id: Optional[str]
-    has_more: Optional[bool]
+    first_id: Optional[str] = None
+    last_id: Optional[str] = None
+    has_more: Optional[bool] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):

--- a/portkey_ai/api_resources/types/thread_run_type.py
+++ b/portkey_ai/api_resources/types/thread_run_type.py
@@ -38,34 +38,34 @@ __all__ = [
 ]
 
 
-class Function(BaseModel):
+class Function(BaseModel, extra="allow"):
     arguments: Optional[str]
     name: Optional[str]
     output: Optional[str] = None
 
 
-class FunctionToolCall(BaseModel):
+class FunctionToolCall(BaseModel, extra="allow"):
     id: Optional[str]
     function: Function
     type: Literal["function"]
 
 
-class RetrievalToolCall(BaseModel):
+class RetrievalToolCall(BaseModel, extra="allow"):
     id: Optional[str]
     retrieval: Optional[object]
     type: Optional[str]
 
 
-class CodeInterpreterOutputLogs(BaseModel):
+class CodeInterpreterOutputLogs(BaseModel, extra="allow"):
     logs: Optional[str]
     type: Optional[str]
 
 
-class CodeInterpreterOutputImageImage(BaseModel):
+class CodeInterpreterOutputImageImage(BaseModel, extra="allow"):
     file_id: Optional[str]
 
 
-class CodeInterpreterOutputImage(BaseModel):
+class CodeInterpreterOutputImage(BaseModel, extra="allow"):
     image: CodeInterpreterOutputImageImage
     type: Optional[str]
 
@@ -73,12 +73,12 @@ class CodeInterpreterOutputImage(BaseModel):
 CodeInterpreterOutput = Union[CodeInterpreterOutputLogs, CodeInterpreterOutputImage]
 
 
-class CodeInterpreter(BaseModel):
+class CodeInterpreter(BaseModel, extra="allow"):
     input: Optional[str]
     outputs: List[CodeInterpreterOutput]
 
 
-class CodeToolCall(BaseModel):
+class CodeToolCall(BaseModel, extra="allow"):
     id: Optional[str]
     code_interpreter: CodeInterpreter
     type: Optional[str]
@@ -87,16 +87,16 @@ class CodeToolCall(BaseModel):
 ToolCall = Union[CodeToolCall, RetrievalToolCall, FunctionToolCall]
 
 
-class ToolCallsStepDetails(BaseModel):
+class ToolCallsStepDetails(BaseModel, extra="allow"):
     tool_calls: Optional[List[ToolCall]]
     type: Optional[str]
 
 
-class MessageCreation(BaseModel):
+class MessageCreation(BaseModel, extra="allow"):
     message_id: Optional[str]
 
 
-class MessageCreationStepDetails(BaseModel):
+class MessageCreationStepDetails(BaseModel, extra="allow"):
     message_creation: Optional[MessageCreation]
 
     type: Optional[str]
@@ -105,33 +105,33 @@ class MessageCreationStepDetails(BaseModel):
 StepDetails = Union[MessageCreationStepDetails, ToolCallsStepDetails]
 
 
-class Usage(BaseModel):
+class Usage(BaseModel, extra="allow"):
     completion_tokens: Optional[int]
     prompt_tokens: Optional[int]
     total_tokens: Optional[int]
 
 
-class LastError(BaseModel):
+class LastError(BaseModel, extra="allow"):
     code: Optional[str]
     message: Optional[str]
 
 
-class FunctionRA(BaseModel):
+class FunctionRA(BaseModel, extra="allow"):
     arguments: Optional[str]
     name: Optional[str]
 
 
-class RequiredActionFunctionToolCall(BaseModel):
+class RequiredActionFunctionToolCall(BaseModel, extra="allow"):
     id: Optional[str]
     function: Optional[FunctionRA]
     type: Optional[str]
 
 
-class RequiredActionSubmitToolOutputs(BaseModel):
+class RequiredActionSubmitToolOutputs(BaseModel, extra="allow"):
     tool_calls: Optional[List[RequiredActionFunctionToolCall]]
 
 
-class RequiredAction(BaseModel):
+class RequiredAction(BaseModel, extra="allow"):
     submit_tool_outputs: Optional[RequiredActionSubmitToolOutputs]
     type: Optional[str]
 
@@ -139,21 +139,21 @@ class RequiredAction(BaseModel):
 FunctionParameters = Dict[str, object]
 
 
-class FunctionDefinition(BaseModel):
+class FunctionDefinition(BaseModel, extra="allow"):
     name: Optional[str]
     description: Optional[str] = None
     parameters: Optional[FunctionParameters] = None
 
 
-class ToolAssistantToolsCode(BaseModel):
+class ToolAssistantToolsCode(BaseModel, extra="allow"):
     type: Optional[str]
 
 
-class ToolAssistantToolsRetrieval(BaseModel):
+class ToolAssistantToolsRetrieval(BaseModel, extra="allow"):
     type: Optional[str]
 
 
-class ToolAssistantToolsFunction(BaseModel):
+class ToolAssistantToolsFunction(BaseModel, extra="allow"):
     function: Optional[FunctionDefinition]
     type: Optional[str]
 
@@ -163,7 +163,7 @@ Tool = Union[
 ]
 
 
-class Run(BaseModel):
+class Run(BaseModel, extra="allow"):
     id: Optional[str]
     assistant_id: Optional[str]
     cancelled_at: Optional[int] = None

--- a/portkey_ai/api_resources/types/thread_type.py
+++ b/portkey_ai/api_resources/types/thread_type.py
@@ -9,10 +9,10 @@ __all__ = ["Thread", "ThreadDeleted"]
 
 
 class Thread(BaseModel, extra="allow"):
-    id: Optional[str]
-    created_at: Optional[int]
+    id: Optional[str] = None
+    created_at: Optional[int] = None
     metadata: Optional[object] = None
-    object: Optional[str]
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
@@ -24,9 +24,9 @@ class Thread(BaseModel, extra="allow"):
 
 
 class ThreadDeleted(BaseModel, extra="allow"):
-    id: Optional[str]
-    object: Optional[str]
-    deleted: Optional[bool]
+    id: Optional[str] = None
+    object: Optional[str] = None
+    deleted: Optional[bool] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):

--- a/portkey_ai/api_resources/types/thread_type.py
+++ b/portkey_ai/api_resources/types/thread_type.py
@@ -1,11 +1,31 @@
 import json
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 import httpx
 from .utils import parse_headers
 from pydantic import BaseModel, PrivateAttr
 
 
-__all__ = ["Thread", "ThreadDeleted"]
+__all__ = [
+    "Thread",
+    "ThreadDeleted",
+    "ToolResources",
+    "ToolResourcesCodeInterpreter",
+    "ToolResourcesFileSearch",
+]
+
+
+class ToolResourcesCodeInterpreter(BaseModel, extra="allow"):
+    file_ids: Optional[List[str]] = None
+
+
+class ToolResourcesFileSearch(BaseModel, extra="allow"):
+    vector_store_ids: Optional[List[str]] = None
+
+
+class ToolResources(BaseModel, extra="allow"):
+    code_interpreter: Optional[ToolResourcesCodeInterpreter] = None
+
+    file_search: Optional[ToolResourcesFileSearch] = None
 
 
 class Thread(BaseModel, extra="allow"):
@@ -13,6 +33,7 @@ class Thread(BaseModel, extra="allow"):
     created_at: Optional[int] = None
     metadata: Optional[object] = None
     object: Optional[str] = None
+    tool_resources: Optional[ToolResources] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):

--- a/portkey_ai/api_resources/types/upload_types.py
+++ b/portkey_ai/api_resources/types/upload_types.py
@@ -8,13 +8,13 @@ from pydantic import BaseModel, PrivateAttr
 
 
 class Upload(BaseModel, extra="allow"):
-    id: Optional[str]
-    bytes: Optional[int]
-    created_at: Optional[int]
-    expires_at: Optional[int]
-    filename: Optional[str]
+    id: Optional[str] = None
+    bytes: Optional[int] = None
+    created_at: Optional[int] = None
+    expires_at: Optional[int] = None
+    filename: Optional[str] = None
     object: Optional[Literal["upload"]]
-    purpose: Optional[str]
+    purpose: Optional[str] = None
     status: Optional[Literal["pending", "completed", "cancelled", "expired"]]
     file: Optional[FileObject] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
@@ -28,10 +28,10 @@ class Upload(BaseModel, extra="allow"):
 
 
 class UploadPart(BaseModel, extra="allow"):
-    id: Optional[str]
-    created_at: Optional[int]
+    id: Optional[str] = None
+    created_at: Optional[int] = None
     object: Optional[Literal["upload.part"]]
-    upload_id: Optional[str]
+    upload_id: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):

--- a/portkey_ai/api_resources/types/upload_types.py
+++ b/portkey_ai/api_resources/types/upload_types.py
@@ -2,9 +2,19 @@ import json
 from typing import Dict, Literal, Optional
 import httpx
 
-from portkey_ai._vendor.openai.types.file_object import FileObject
 from .utils import parse_headers
 from pydantic import BaseModel, PrivateAttr
+
+
+class FileObject(BaseModel, extra="allow"):
+    id: Optional[str] = None
+    bytes: Optional[int] = None
+    created_at: Optional[int] = None
+    filename: Optional[str] = None
+    object: Optional[str] = None
+    purpose: Optional[str] = None
+    status: Optional[str] = None
+    status_details: Optional[str] = None
 
 
 class Upload(BaseModel, extra="allow"):

--- a/portkey_ai/api_resources/types/user_invite_type.py
+++ b/portkey_ai/api_resources/types/user_invite_type.py
@@ -6,14 +6,14 @@ from portkey_ai.api_resources.types.utils import parse_headers
 
 
 class UserRetrieveResponse(BaseModel, extra="allow"):
-    object: Optional[str]
-    id: Optional[str]
-    first_name: Optional[str]
-    last_name: Optional[str]
-    role: Optional[str]
-    email: Optional[str]
-    created_at: Optional[str]
-    last_updated_at: Optional[str]
+    object: Optional[str] = None
+    id: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    role: Optional[str] = None
+    email: Optional[str] = None
+    created_at: Optional[str] = None
+    last_updated_at: Optional[str] = None
     workspace_ids: Optional[List[str]] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
@@ -31,8 +31,8 @@ class UserRetrieveResponse(BaseModel, extra="allow"):
 
 
 class UserRetrieveAllResponse(BaseModel, extra="allow"):
-    total: Optional[int]
-    object: Optional[str]
+    total: Optional[int] = None
+    object: Optional[str] = None
     data: Optional[List[UserRetrieveResponse]]
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
@@ -50,8 +50,8 @@ class UserRetrieveAllResponse(BaseModel, extra="allow"):
 
 
 class UserInviteResponse(BaseModel, extra="allow"):
-    id: Optional[str]
-    invite_link: Optional[str]
+    id: Optional[str] = None
+    invite_link: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -68,15 +68,15 @@ class UserInviteResponse(BaseModel, extra="allow"):
 
 
 class UserInviteRetrieveResponse(BaseModel, extra="allow"):
-    object: Optional[str]
-    id: Optional[str]
-    email: Optional[str]
-    role: Optional[str]
-    created_at: Optional[str]
-    expires_at: Optional[str]
-    accepted_at: Optional[str]
-    status: Optional[str]
-    invited_by: Optional[str]
+    object: Optional[str] = None
+    id: Optional[str] = None
+    email: Optional[str] = None
+    role: Optional[str] = None
+    created_at: Optional[str] = None
+    expires_at: Optional[str] = None
+    accepted_at: Optional[str] = None
+    status: Optional[str] = None
+    invited_by: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -93,8 +93,8 @@ class UserInviteRetrieveResponse(BaseModel, extra="allow"):
 
 
 class UserInviteRetrieveAllResponse(BaseModel, extra="allow"):
-    object: Optional[str]
-    total: Optional[int]
+    object: Optional[str] = None
+    total: Optional[int] = None
     data: Optional[List[UserInviteRetrieveResponse]]
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
@@ -112,15 +112,15 @@ class UserInviteRetrieveAllResponse(BaseModel, extra="allow"):
 
 
 class WorkspacesAddResponse(BaseModel, extra="allow"):
-    id: Optional[str]
-    slug: Optional[str]
-    name: Optional[str]
-    description: Optional[str]
-    created_at: Optional[str]
-    last_updated_at: Optional[str]
-    defaults: Optional[Dict[str, Any]]
-    users: Optional[List[Dict[str, str]]]
-    object: Optional[str]
+    id: Optional[str] = None
+    slug: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    created_at: Optional[str] = None
+    last_updated_at: Optional[str] = None
+    defaults: Optional[Dict[str, Any]] = None
+    users: Optional[List[Dict[str, str]]] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -137,14 +137,14 @@ class WorkspacesAddResponse(BaseModel, extra="allow"):
 
 
 class WorkspacesGetResponse(BaseModel, extra="allow"):
-    object: Optional[str]
-    id: Optional[str]
-    slug: Optional[str]
-    name: Optional[str]
-    description: Optional[str]
-    created_at: Optional[str]
-    last_updated_at: Optional[str]
-    defaults: Optional[Dict[str, Any]]
+    object: Optional[str] = None
+    id: Optional[str] = None
+    slug: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    created_at: Optional[str] = None
+    last_updated_at: Optional[str] = None
+    defaults: Optional[Dict[str, Any]] = None
     is_default: Optional[int] = None
     users: Optional[List[Dict[str, Any]]] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
@@ -163,8 +163,8 @@ class WorkspacesGetResponse(BaseModel, extra="allow"):
 
 
 class WorkspacesListResponse(BaseModel, extra="allow"):
-    total: Optional[int]
-    object: Optional[str]
+    total: Optional[int] = None
+    object: Optional[str] = None
     data: Optional[List[WorkspacesGetResponse]]
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
@@ -182,15 +182,15 @@ class WorkspacesListResponse(BaseModel, extra="allow"):
 
 
 class WorkspacesUpdateResponse(BaseModel, extra="allow"):
-    id: Optional[str]
-    slug: Optional[str]
-    name: Optional[str]
-    description: Optional[str]
-    created_at: Optional[str]
-    is_default: Optional[int]
-    last_updated_at: Optional[str]
-    defaults: Optional[Dict[str, Any]]
-    object: Optional[str]
+    id: Optional[str] = None
+    slug: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    created_at: Optional[str] = None
+    is_default: Optional[int] = None
+    last_updated_at: Optional[str] = None
+    defaults: Optional[Dict[str, Any]] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -207,17 +207,17 @@ class WorkspacesUpdateResponse(BaseModel, extra="allow"):
 
 
 class WorkspaceMemberGetResponse(BaseModel, extra="allow"):
-    first_name: Optional[str]
-    last_name: Optional[str]
-    org_role: Optional[str]
-    role: Optional[str]
-    created_at: Optional[str]
-    last_updated_at: Optional[str]
-    status: Optional[str]
-    workspace_id: Optional[str]
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    org_role: Optional[str] = None
+    role: Optional[str] = None
+    created_at: Optional[str] = None
+    last_updated_at: Optional[str] = None
+    status: Optional[str] = None
+    workspace_id: Optional[str] = None
     scopes: Optional[List[str]] = None
     settings: Optional[Any] = None
-    object: Optional[str]
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -234,8 +234,8 @@ class WorkspaceMemberGetResponse(BaseModel, extra="allow"):
 
 
 class WorkspaceMemberListResponse(BaseModel, extra="allow"):
-    total: Optional[int]
-    object: Optional[str]
+    total: Optional[int] = None
+    object: Optional[str] = None
     data: Optional[List[WorkspaceMemberGetResponse]]
     _headers: Optional[httpx.Headers] = PrivateAttr()
 

--- a/portkey_ai/api_resources/types/user_invite_type.py
+++ b/portkey_ai/api_resources/types/user_invite_type.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, PrivateAttr
 from portkey_ai.api_resources.types.utils import parse_headers
 
 
-class UserRetrieveResponse(BaseModel):
+class UserRetrieveResponse(BaseModel, extra="allow"):
     object: Optional[str]
     id: Optional[str]
     first_name: Optional[str]
@@ -30,7 +30,7 @@ class UserRetrieveResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class UserRetrieveAllResponse(BaseModel):
+class UserRetrieveAllResponse(BaseModel, extra="allow"):
     total: Optional[int]
     object: Optional[str]
     data: Optional[List[UserRetrieveResponse]]
@@ -49,7 +49,7 @@ class UserRetrieveAllResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class UserInviteResponse(BaseModel):
+class UserInviteResponse(BaseModel, extra="allow"):
     id: Optional[str]
     invite_link: Optional[str]
     _headers: Optional[httpx.Headers] = PrivateAttr()
@@ -67,7 +67,7 @@ class UserInviteResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class UserInviteRetrieveResponse(BaseModel):
+class UserInviteRetrieveResponse(BaseModel, extra="allow"):
     object: Optional[str]
     id: Optional[str]
     email: Optional[str]
@@ -92,7 +92,7 @@ class UserInviteRetrieveResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class UserInviteRetrieveAllResponse(BaseModel):
+class UserInviteRetrieveAllResponse(BaseModel, extra="allow"):
     object: Optional[str]
     total: Optional[int]
     data: Optional[List[UserInviteRetrieveResponse]]
@@ -111,7 +111,7 @@ class UserInviteRetrieveAllResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class WorkspacesAddResponse(BaseModel):
+class WorkspacesAddResponse(BaseModel, extra="allow"):
     id: Optional[str]
     slug: Optional[str]
     name: Optional[str]
@@ -136,7 +136,7 @@ class WorkspacesAddResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class WorkspacesGetResponse(BaseModel):
+class WorkspacesGetResponse(BaseModel, extra="allow"):
     object: Optional[str]
     id: Optional[str]
     slug: Optional[str]
@@ -162,7 +162,7 @@ class WorkspacesGetResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class WorkspacesListResponse(BaseModel):
+class WorkspacesListResponse(BaseModel, extra="allow"):
     total: Optional[int]
     object: Optional[str]
     data: Optional[List[WorkspacesGetResponse]]
@@ -181,7 +181,7 @@ class WorkspacesListResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class WorkspacesUpdateResponse(BaseModel):
+class WorkspacesUpdateResponse(BaseModel, extra="allow"):
     id: Optional[str]
     slug: Optional[str]
     name: Optional[str]
@@ -206,7 +206,7 @@ class WorkspacesUpdateResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class WorkspaceMemberGetResponse(BaseModel):
+class WorkspaceMemberGetResponse(BaseModel, extra="allow"):
     first_name: Optional[str]
     last_name: Optional[str]
     org_role: Optional[str]
@@ -233,7 +233,7 @@ class WorkspaceMemberGetResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class WorkspaceMemberListResponse(BaseModel):
+class WorkspaceMemberListResponse(BaseModel, extra="allow"):
     total: Optional[int]
     object: Optional[str]
     data: Optional[List[WorkspaceMemberGetResponse]]

--- a/portkey_ai/api_resources/types/vector_stores_type.py
+++ b/portkey_ai/api_resources/types/vector_stores_type.py
@@ -25,7 +25,7 @@ __all__ = [
 ]
 
 
-class FileCounts(BaseModel):
+class FileCounts(BaseModel, extra="allow"):
     cancelled: int
     completed: int
     failed: int
@@ -33,12 +33,12 @@ class FileCounts(BaseModel):
     total: int
 
 
-class ExpiresAfter(BaseModel):
+class ExpiresAfter(BaseModel, extra="allow"):
     anchor: str
     days: int
 
 
-class VectorStore(BaseModel):
+class VectorStore(BaseModel, extra="allow"):
     id: str
     created_at: int
     file_counts: FileCounts
@@ -60,7 +60,7 @@ class VectorStore(BaseModel):
         return parse_headers(self._headers)
 
 
-class VectorStoreList(BaseModel):
+class VectorStoreList(BaseModel, extra="allow"):
     data: List[VectorStore]
     object: str
     _headers: Optional[httpx.Headers] = PrivateAttr()
@@ -73,7 +73,7 @@ class VectorStoreList(BaseModel):
         return parse_headers(self._headers)
 
 
-class VectorStoreDeleted(BaseModel):
+class VectorStoreDeleted(BaseModel, extra="allow"):
     id: str
     deleted: bool
     object: str
@@ -87,7 +87,7 @@ class VectorStoreDeleted(BaseModel):
         return parse_headers(self._headers)
 
 
-class LastError(BaseModel):
+class LastError(BaseModel, extra="allow"):
     code: str
     message: str
 
@@ -98,7 +98,7 @@ ChunkingStrategy: TypeAlias = Annotated[
 ]
 
 
-class VectorStoreFile(BaseModel):
+class VectorStoreFile(BaseModel, extra="allow"):
     id: str
     created_at: int
     last_error: Optional[LastError] = None
@@ -117,7 +117,7 @@ class VectorStoreFile(BaseModel):
         return parse_headers(self._headers)
 
 
-class VectorStoreFileList(BaseModel):
+class VectorStoreFileList(BaseModel, extra="allow"):
     data: List[VectorStoreFile]
     object: str
     _headers: Optional[httpx.Headers] = PrivateAttr()
@@ -130,7 +130,7 @@ class VectorStoreFileList(BaseModel):
         return parse_headers(self._headers)
 
 
-class VectorStoreFileDeleted(BaseModel):
+class VectorStoreFileDeleted(BaseModel, extra="allow"):
     id: str
     deleted: bool
     object: str
@@ -144,7 +144,7 @@ class VectorStoreFileDeleted(BaseModel):
         return parse_headers(self._headers)
 
 
-class VectorStoreFileBatch(BaseModel):
+class VectorStoreFileBatch(BaseModel, extra="allow"):
     id: str
     created_at: int
     file_counts: FileCounts

--- a/portkey_ai/api_resources/types/vector_stores_type.py
+++ b/portkey_ai/api_resources/types/vector_stores_type.py
@@ -26,28 +26,28 @@ __all__ = [
 
 
 class FileCounts(BaseModel, extra="allow"):
-    cancelled: int
-    completed: int
-    failed: int
-    in_progress: int
-    total: int
+    cancelled: Optional[int] = None
+    completed: Optional[int] = None
+    failed: Optional[int] = None
+    in_progress: Optional[int] = None
+    total: Optional[int] = None
 
 
 class ExpiresAfter(BaseModel, extra="allow"):
-    anchor: str
-    days: int
+    anchor: Optional[str] = None
+    days: Optional[int] = None
 
 
 class VectorStore(BaseModel, extra="allow"):
-    id: str
-    created_at: int
+    id: Optional[str] = None
+    created_at: Optional[int] = None
     file_counts: FileCounts
     last_active_at: Optional[int] = None
     metadata: Optional[object] = None
-    name: str
-    object: str
-    status: str
-    usage_bytes: int
+    name: Optional[str] = None
+    object: Optional[str] = None
+    status: Optional[str] = None
+    usage_bytes: Optional[int] = None
     expires_after: Optional[ExpiresAfter] = None
     expires_at: Optional[int] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
@@ -62,7 +62,7 @@ class VectorStore(BaseModel, extra="allow"):
 
 class VectorStoreList(BaseModel, extra="allow"):
     data: List[VectorStore]
-    object: str
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
@@ -74,9 +74,9 @@ class VectorStoreList(BaseModel, extra="allow"):
 
 
 class VectorStoreDeleted(BaseModel, extra="allow"):
-    id: str
-    deleted: bool
-    object: str
+    id: Optional[str] = None
+    deleted: Optional[bool] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
@@ -88,8 +88,8 @@ class VectorStoreDeleted(BaseModel, extra="allow"):
 
 
 class LastError(BaseModel, extra="allow"):
-    code: str
-    message: str
+    code: Optional[str] = None
+    message: Optional[str] = None
 
 
 ChunkingStrategy: TypeAlias = Annotated[
@@ -99,13 +99,13 @@ ChunkingStrategy: TypeAlias = Annotated[
 
 
 class VectorStoreFile(BaseModel, extra="allow"):
-    id: str
-    created_at: int
+    id: Optional[str] = None
+    created_at: Optional[int] = None
     last_error: Optional[LastError] = None
-    object: str
-    status: str
-    usage_bytes: int
-    vector_store_id: str
+    object: Optional[str] = None
+    status: Optional[str] = None
+    usage_bytes: Optional[int] = None
+    vector_store_id: Optional[str] = None
     chunking_strategy: Optional[ChunkingStrategy] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
@@ -119,7 +119,7 @@ class VectorStoreFile(BaseModel, extra="allow"):
 
 class VectorStoreFileList(BaseModel, extra="allow"):
     data: List[VectorStoreFile]
-    object: str
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
@@ -131,9 +131,9 @@ class VectorStoreFileList(BaseModel, extra="allow"):
 
 
 class VectorStoreFileDeleted(BaseModel, extra="allow"):
-    id: str
-    deleted: bool
-    object: str
+    id: Optional[str] = None
+    deleted: Optional[bool] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):
@@ -145,12 +145,12 @@ class VectorStoreFileDeleted(BaseModel, extra="allow"):
 
 
 class VectorStoreFileBatch(BaseModel, extra="allow"):
-    id: str
-    created_at: int
+    id: Optional[str] = None
+    created_at: Optional[int] = None
     file_counts: FileCounts
-    object: str
-    status: str
-    vector_store_id: str
+    object: Optional[str] = None
+    status: Optional[str] = None
+    vector_store_id: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def __str__(self):

--- a/portkey_ai/api_resources/types/virtual_keys_type.py
+++ b/portkey_ai/api_resources/types/virtual_keys_type.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, PrivateAttr
 from portkey_ai.api_resources.types.utils import parse_headers
 
 
-class VirtualKeysAddResponse(BaseModel):
+class VirtualKeysAddResponse(BaseModel, extra="allow"):
     id: Optional[str]
     slug: Optional[str]
     object: Optional[str]
@@ -24,7 +24,7 @@ class VirtualKeysAddResponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class VirtualKeysListReponse(BaseModel):
+class VirtualKeysListReponse(BaseModel, extra="allow"):
     object: Optional[str]
     total: Optional[int]
     data: Optional[List[Dict[str, Any]]]
@@ -43,7 +43,7 @@ class VirtualKeysListReponse(BaseModel):
         return getattr(self, key, None) or default
 
 
-class VirtualKeysUpdateResponse(BaseModel):
+class VirtualKeysUpdateResponse(BaseModel, extra="allow"):
     id: Optional[str]
     slug: Optional[str]
     object: Optional[str]

--- a/portkey_ai/api_resources/types/virtual_keys_type.py
+++ b/portkey_ai/api_resources/types/virtual_keys_type.py
@@ -6,9 +6,9 @@ from portkey_ai.api_resources.types.utils import parse_headers
 
 
 class VirtualKeysAddResponse(BaseModel, extra="allow"):
-    id: Optional[str]
-    slug: Optional[str]
-    object: Optional[str]
+    id: Optional[str] = None
+    slug: Optional[str] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -25,9 +25,9 @@ class VirtualKeysAddResponse(BaseModel, extra="allow"):
 
 
 class VirtualKeysListReponse(BaseModel, extra="allow"):
-    object: Optional[str]
-    total: Optional[int]
-    data: Optional[List[Dict[str, Any]]]
+    object: Optional[str] = None
+    total: Optional[int] = None
+    data: Optional[List[Dict[str, Any]]] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:
@@ -44,9 +44,9 @@ class VirtualKeysListReponse(BaseModel, extra="allow"):
 
 
 class VirtualKeysUpdateResponse(BaseModel, extra="allow"):
-    id: Optional[str]
-    slug: Optional[str]
-    object: Optional[str]
+    id: Optional[str] = None
+    slug: Optional[str] = None
+    object: Optional[str] = None
     _headers: Optional[httpx.Headers] = PrivateAttr()
 
     def get_headers(self) -> Optional[Dict[str, str]]:

--- a/portkey_ai/api_resources/utils.py
+++ b/portkey_ai/api_resources/utils.py
@@ -5,7 +5,7 @@ from enum import Enum, EnumMeta
 from typing_extensions import TypedDict, NotRequired
 import httpx
 import portkey_ai
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel
 
 from portkey_ai.api_resources.types.chat_complete_type import (
     ChatCompletionChunk,
@@ -283,7 +283,6 @@ class Constructs(BaseModel):
 
 
 class LLMOptions(Constructs, ConversationInput, ModelParams):
-    @field_validator("api_key", "virtual_key")
     @classmethod
     def parse_api_key(cls, api_key, values):
         if api_key is None and values.get("virtual_key") is None:
@@ -296,7 +295,6 @@ class LLMOptions(Constructs, ConversationInput, ModelParams):
 class ProviderOptions(Constructs):
     override_params: Optional[OverrideParams] = None
 
-    @field_validator("cache_age")
     @classmethod
     def parse_cache_age(cls, cache_age):
         if cache_age is not None:
@@ -418,7 +416,6 @@ class Config(BaseModel):
     mode: Optional[Union[Modes, ModesLiteral, str]] = None
     llms: Optional[Union[List[LLMOptions], LLMOptions]] = None
 
-    @field_validator("mode")
     @classmethod
     def check_mode(cls, mode):
         if mode is None:
@@ -427,7 +424,6 @@ class Config(BaseModel):
 
         return mode
 
-    @field_validator("llms")
     @classmethod
     def parse_llms(cls, llms):
         if isinstance(llms, LLMOptions):

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ include_package_data = True
 install_requires =
   httpx
   typing_extensions>=4.7.1,<5.0
-  pydantic>=1.10.0
+  pydantic>=1.10.8
   anyio>=3.5.0,<5
   distro>=1.7.0,<2
   sniffio


### PR DESCRIPTION
**Title:** Pydantic versioning

**Description:**
- Handled case of user's pydantic v1 dependency 
- Added types for beta.chat.completion
- Added type for chat.completion
- Added extra="allow" for all the types
- Setting None as default value for the Optional Keys
- Adding more type classes for the Threads route
- Minimum required pydantic version 1.10.8 (advised to use 2.0 [suggested, as per pydantic docs])

**Motivation:**
User reported issue, pydantic version mismatch while using other SDKs

**Related Issues:**
Closes: #247 #252
