### PR TITLE
Metadata for API Keys

### DIFF
--- a/portkey_ai/api_resources/apis/api_keys.py
+++ b/portkey_ai/api_resources/apis/api_keys.py
@@ -164,7 +164,9 @@ class AsyncApiKeys(AsyncAPIResource):
             "rate_limits": rate_limits,
             "usage_limits": usage_limits,
             "scopes": scopes,
-            "defaults": defaults,
+            "defaults": defaults
+            if defaults is not None
+            else {"config_id": None, "metadata": None},
         }
         return await self._post(
             f"{PortkeyApiPaths.API_KEYS_API}/{type}/{sub_type}",
@@ -229,7 +231,9 @@ class AsyncApiKeys(AsyncAPIResource):
             "rate_limits": rate_limits,
             "usage_limits": usage_limits,
             "scopes": scopes,
-            "defaults": defaults,
+            "defaults": defaults
+            if defaults is not None
+            else {"config_id": None, "metadata": None},
         }
         return await self._put(
             f"{PortkeyApiPaths.API_KEYS_API}/{id}",

--- a/portkey_ai/api_resources/apis/api_keys.py
+++ b/portkey_ai/api_resources/apis/api_keys.py
@@ -39,7 +39,9 @@ class ApiKeys(APIResource):
             "rate_limits": rate_limits,
             "usage_limits": usage_limits,
             "scopes": scopes,
-            "defaults": defaults,
+            "defaults": defaults
+            if defaults is not None
+            else {"config_id": None, "metadata": None},
         }
         return self._post(
             f"{PortkeyApiPaths.API_KEYS_API}/{type}/{sub_type}",
@@ -104,7 +106,9 @@ class ApiKeys(APIResource):
             "rate_limits": rate_limits,
             "usage_limits": usage_limits,
             "scopes": scopes,
-            "defaults": defaults,
+            "defaults": defaults
+            if defaults is not None
+            else {"config_id": None, "metadata": None},
         }
         return self._put(
             f"{PortkeyApiPaths.API_KEYS_API}/{id}",


### PR DESCRIPTION
**Title:** Metadata for API Keys

**Description:**
- Setting null as default metadata if not being passed by the user

**Motivation:**
Matching the payload from the Web, to fill the default values

**Related Issues:**
Closes: #285