### PR TITLE
Headers in Prompt Completions

### DIFF
--- a/portkey_ai/api_resources/apis/chat_complete.py
+++ b/portkey_ai/api_resources/apis/chat_complete.py
@@ -71,6 +71,7 @@ class Completions(APIResource):
         store,
         **kwargs,
     ) -> Union[ChatCompletions, Iterator[ChatCompletionChunk]]:
+        extra_headers = kwargs.get("extra_headers", {})
         with self.openai_client.with_streaming_response.chat.completions.create(
             model=model,
             messages=messages,
@@ -85,6 +86,7 @@ class Completions(APIResource):
             prediction=prediction,
             reasoning_effort=reasoning_effort,
             store=store,
+            extra_headers=extra_headers,
             extra_body=kwargs,
         ) as response:
             for line in response.iter_lines():
@@ -118,6 +120,7 @@ class Completions(APIResource):
         store,
         **kwargs,
     ) -> ChatCompletions:
+        extra_headers = kwargs.get("extra_headers", {})
         response = self.openai_client.with_raw_response.chat.completions.create(
             model=model,
             messages=messages,
@@ -132,6 +135,7 @@ class Completions(APIResource):
             prediction=prediction,
             reasoning_effort=reasoning_effort,
             store=store,
+            extra_headers=extra_headers,
             extra_body=kwargs,
         )
         data = ChatCompletions(**json.loads(response.text))
@@ -315,6 +319,7 @@ class AsyncCompletions(AsyncAPIResource):
         store,
         **kwargs,
     ) -> Union[ChatCompletions, AsyncIterator[ChatCompletionChunk]]:
+        extra_headers = kwargs.get("extra_headers", {})
         async with self.openai_client.with_streaming_response.chat.completions.create(
             model=model,
             messages=messages,
@@ -329,6 +334,7 @@ class AsyncCompletions(AsyncAPIResource):
             prediction=prediction,
             reasoning_effort=reasoning_effort,
             store=store,
+            extra_headers=extra_headers,
             extra_body=kwargs,
         ) as response:
             async for line in response.iter_lines():
@@ -362,6 +368,7 @@ class AsyncCompletions(AsyncAPIResource):
         store,
         **kwargs,
     ) -> ChatCompletions:
+        extra_headers = kwargs.get("extra_headers", {})
         response = await self.openai_client.with_raw_response.chat.completions.create(
             model=model,
             messages=messages,
@@ -376,6 +383,7 @@ class AsyncCompletions(AsyncAPIResource):
             prediction=prediction,
             reasoning_effort=reasoning_effort,
             store=store,
+            extra_headers=extra_headers,
             extra_body=kwargs,
         )
         data = ChatCompletions(**json.loads(response.text))

--- a/portkey_ai/api_resources/apis/generation.py
+++ b/portkey_ai/api_resources/apis/generation.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import warnings
 from typing import Literal, Optional, Union, Mapping, Any, overload
-from portkey_ai.api_resources.apis.create_headers import createHeaders
 from portkey_ai.api_resources.base_client import APIClient, AsyncAPIClient
 from portkey_ai.api_resources.types.generation_type import (
     PromptCompletion,
@@ -245,7 +244,7 @@ class Completions(APIResource):
             **kwargs,
         }
 
-        extra_headers = createHeaders(**extra_headers)
+        extra_headers = extra_headers
 
         return self._post(
             f"/prompts/{prompt_id}/completions",
@@ -340,7 +339,7 @@ class AsyncCompletions(AsyncAPIResource):
             **kwargs,
         }
 
-        extra_headers = createHeaders(**extra_headers)
+        extra_headers = extra_headers
 
         return await self._post(
             f"/prompts/{prompt_id}/completions",

--- a/portkey_ai/api_resources/apis/generation.py
+++ b/portkey_ai/api_resources/apis/generation.py
@@ -244,8 +244,6 @@ class Completions(APIResource):
             **kwargs,
         }
 
-        extra_headers = extra_headers
-
         return self._post(
             f"/prompts/{prompt_id}/completions",
             body=body,
@@ -338,8 +336,6 @@ class AsyncCompletions(AsyncAPIResource):
             "stream": stream,
             **kwargs,
         }
-
-        extra_headers = extra_headers
 
         return await self._post(
             f"/prompts/{prompt_id}/completions",

--- a/portkey_ai/api_resources/apis/generation.py
+++ b/portkey_ai/api_resources/apis/generation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import warnings
 from typing import Literal, Optional, Union, Mapping, Any, overload
+from portkey_ai.api_resources.apis.create_headers import createHeaders
 from portkey_ai.api_resources.base_client import APIClient, AsyncAPIClient
 from portkey_ai.api_resources.types.generation_type import (
     PromptCompletion,
@@ -178,6 +179,7 @@ class Completions(APIResource):
         max_tokens: Optional[int] = None,
         top_k: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_headers: Mapping[str, str] = {},
         **kwargs,
     ) -> Stream[PromptCompletionChunk]:
         ...
@@ -194,6 +196,7 @@ class Completions(APIResource):
         max_tokens: Optional[int] = None,
         top_k: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_headers: Mapping[str, str] = {},
         **kwargs,
     ) -> PromptCompletion:
         ...
@@ -210,6 +213,7 @@ class Completions(APIResource):
         max_tokens: Optional[int] = None,
         top_k: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_headers: Mapping[str, str] = {},
         **kwargs,
     ) -> Union[PromptCompletion, Stream[PromptCompletionChunk]]:
         ...
@@ -225,6 +229,7 @@ class Completions(APIResource):
         max_tokens: Optional[int] = None,
         top_k: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_headers: Mapping[str, str] = {},
         **kwargs,
     ) -> Union[PromptCompletion, Stream[PromptCompletionChunk],]:
         """Prompt completions Method"""
@@ -239,6 +244,9 @@ class Completions(APIResource):
             "stream": stream,
             **kwargs,
         }
+
+        extra_headers = createHeaders(**extra_headers)
+
         return self._post(
             f"/prompts/{prompt_id}/completions",
             body=body,
@@ -246,7 +254,7 @@ class Completions(APIResource):
             cast_to=PromptCompletion,
             stream_cls=Stream[PromptCompletionChunk],
             stream=stream,
-            headers={},
+            headers=extra_headers,
         )
 
 
@@ -266,6 +274,7 @@ class AsyncCompletions(AsyncAPIResource):
         max_tokens: Optional[int] = None,
         top_k: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_headers: Mapping[str, str] = {},
         **kwargs,
     ) -> AsyncStream[PromptCompletionChunk]:
         ...
@@ -282,6 +291,7 @@ class AsyncCompletions(AsyncAPIResource):
         max_tokens: Optional[int] = None,
         top_k: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_headers: Mapping[str, str] = {},
         **kwargs,
     ) -> PromptCompletion:
         ...
@@ -298,6 +308,7 @@ class AsyncCompletions(AsyncAPIResource):
         max_tokens: Optional[int] = None,
         top_k: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_headers: Mapping[str, str] = {},
         **kwargs,
     ) -> Union[PromptCompletion, AsyncStream[PromptCompletionChunk]]:
         ...
@@ -313,6 +324,7 @@ class AsyncCompletions(AsyncAPIResource):
         max_tokens: Optional[int] = None,
         top_k: Optional[int] = None,
         top_p: Optional[float] = None,
+        extra_headers: Mapping[str, str] = {},
         **kwargs,
     ) -> Union[PromptCompletion, AsyncStream[PromptCompletionChunk]]:
         """Prompt completions Method"""
@@ -327,6 +339,9 @@ class AsyncCompletions(AsyncAPIResource):
             "stream": stream,
             **kwargs,
         }
+
+        extra_headers = createHeaders(**extra_headers)
+
         return await self._post(
             f"/prompts/{prompt_id}/completions",
             body=body,
@@ -334,5 +349,5 @@ class AsyncCompletions(AsyncAPIResource):
             cast_to=PromptCompletion,
             stream_cls=AsyncStream[PromptCompletionChunk],
             stream=stream,
-            headers={},
+            headers=extra_headers,
         )


### PR DESCRIPTION
**Title:** Headers in Prompt Completions

**Description:**
- Introducing extra_headers argument in prompts.completion.create()
- This helps to avoid the use of with_options for prompt completions call

**Motivation:**
Suggested by user. Helps to avoid creation of portkey client with with_options when custom headers are to be passed

**Related Issues:**
Closes: #308 