### PR TITLE
License warning

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Portkey.ai
+Copyright (c) 2025 Portkey.ai
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,9 +8,9 @@ author = Portkey.ai
 author_email = support@portkey.ai
 url = https://github.com/Portkey-AI/portkey-python-sdk
 license_files = LICENSE
+license = MIT License
 classifiers =
   Programming Language :: Python :: 3
-  License :: OSI Approved :: MIT License
   Operating System :: OS Independent
 
 [options]


### PR DESCRIPTION
**Title:** SetuptoolsDeprecationWarning

**Description:**
- Update classifier
- Update License to 2025

**Motivation:**
Warning on `make build` fixed

**Related Issues:**
Fixes: #333 