### PR TITLE
Random String in the Streaming Response

### DIFF
--- a/portkey_ai/api_resources/apis/chat_complete.py
+++ b/portkey_ai/api_resources/apis/chat_complete.py
@@ -94,6 +94,8 @@ class Completions(APIResource):
                 json_string = json_string.strip().rstrip("\n")
                 if json_string == "":
                     continue
+                if json_string.startswith(":"):
+                    continue
                 elif json_string == "[DONE]":
                     break
                 elif json_string != "":
@@ -341,6 +343,8 @@ class AsyncCompletions(AsyncAPIResource):
                 json_string = line.replace("data: ", "")
                 json_string = json_string.strip().rstrip("\n")
                 if json_string == "":
+                    continue
+                if json_string.startswith(":"):
                     continue
                 elif json_string == "[DONE]":
                     break


### PR DESCRIPTION
**Title:** Random String in the Streaming Response

**Description:**
- Getting a random String in the streaming chunk response.
- `: L1Gt0UZWbB` Now being handled by the SDK

**Motivation:**
Issue reported by user

**Related Issues:**
Fixes: #370 