### PR TITLE
fix: use external openai NotGiven/Omit types for compatibility

### DIFF
--- a/portkey_ai/_vendor/openai/_types.py
+++ b/portkey_ai/_vendor/openai/_types.py
@@ -116,61 +116,70 @@ class RequestOptions(TypedDict, total=False):
 
 
 # Sentinel class used until PEP 0661 is accepted
-class NotGiven:
-    """
-    For parameters with a meaningful None value, we need to distinguish between
-    the user explicitly passing None, and the user not passing the parameter at
-    all.
+# Use external openai's NotGiven/Omit if available for compatibility with libraries
+# that use the standard openai package (e.g., pydantic-ai, langchain)
+try:
+    from openai._types import NotGiven, Omit, NOT_GIVEN
 
-    User code shouldn't need to use not_given directly.
+    # External openai only exports NOT_GIVEN, not the lowercase not_given
+    not_given = NOT_GIVEN
+    # External openai doesn't export lowercase omit, create from class
+    omit = Omit()
+except ImportError:
+    # Fall back to defining our own (for standalone use without openai installed)
 
-    For example:
+    class NotGiven:
+        """
+        For parameters with a meaningful None value, we need to distinguish between
+        the user explicitly passing None, and the user not passing the parameter at
+        all.
 
-    ```py
-    def create(timeout: Timeout | None | NotGiven = not_given): ...
+        User code shouldn't need to use not_given directly.
 
+        For example:
 
-    create(timeout=1)  # 1s timeout
-    create(timeout=None)  # No timeout
-    create()  # Default timeout behavior
-    ```
-    """
-
-    def __bool__(self) -> Literal[False]:
-        return False
-
-    @override
-    def __repr__(self) -> str:
-        return "NOT_GIVEN"
+        ```py
+        def create(timeout: Timeout | None | NotGiven = not_given): ...
 
 
-not_given = NotGiven()
-# for backwards compatibility:
-NOT_GIVEN = NotGiven()
+        create(timeout=1)  # 1s timeout
+        create(timeout=None)  # No timeout
+        create()  # Default timeout behavior
+        ```
+        """
 
+        def __bool__(self) -> Literal[False]:
+            return False
 
-class Omit:
-    """
-    To explicitly omit something from being sent in a request, use `omit`.
+        @override
+        def __repr__(self) -> str:
+            return "NOT_GIVEN"
 
-    ```py
-    # as the default `Content-Type` header is `application/json` that will be sent
-    client.post("/upload/files", files={"file": b"my raw file content"})
+    not_given = NotGiven()
+    # for backwards compatibility:
+    NOT_GIVEN = NotGiven()
 
-    # you can't explicitly override the header as it has to be dynamically generated
-    # to look something like: 'multipart/form-data; boundary=0d8382fcf5f8c3be01ca2e11002d2983'
-    client.post(..., headers={"Content-Type": "multipart/form-data"})
+    class Omit:
+        """
+        To explicitly omit something from being sent in a request, use `omit`.
 
-    # instead you can remove the default `application/json` header by passing omit
-    client.post(..., headers={"Content-Type": omit})
-    ```
-    """
+        ```py
+        # as the default `Content-Type` header is `application/json` that will be sent
+        client.post("/upload/files", files={"file": b"my raw file content"})
 
-    def __bool__(self) -> Literal[False]:
-        return False
+        # you can't explicitly override the header as it has to be dynamically generated
+        # to look something like: 'multipart/form-data; boundary=0d8382fcf5f8c3be01ca2e11002d2983'
+        client.post(..., headers={"Content-Type": "multipart/form-data"})
 
+        # instead you can remove the default `application/json` header by passing omit
+        client.post(..., headers={"Content-Type": omit})
+        ```
+        """
 
-omit = Omit()
+        def __bool__(self) -> Literal[False]:
+            return False
+
+    omit = Omit()
 
 Omittable = Union[_T, Omit]
 


### PR DESCRIPTION
## Problem

When using Portkey with libraries like pydantic-ai that pass `NOT_GIVEN` values from the standard openai package, users encounter:

```
TypeError: Object of type NotGiven is not JSON serializable
```

This happens because Portkey's vendored OpenAI SDK defines its own `NotGiven` class, which is a different class from the standard openai's `NotGiven`. When pydantic-ai passes values using the standard openai's `NOT_GIVEN`, the vendored code doesn't recognize them as `NotGiven` instances.

## Solution

Instead of defining duplicate `NotGiven` and `Omit` classes in the vendored code, we now:

1. **Try to import from the external openai package** if it's installed
2. **Fall back to local definitions** only if openai is not installed

This ensures that when libraries like pydantic-ai pass `NOT_GIVEN` values from the standard openai package, Portkey's vendored SDK recognizes them because they're the exact same class.

## Testing

```python
import openai._types as external_types
import portkey_ai._vendor.openai._types as vendored_types

# Now they're the same class
assert external_types.NotGiven is vendored_types.NotGiven  # ✓
assert external_types.NOT_GIVEN is vendored_types.NOT_GIVEN  # ✓

# isinstance checks work correctly
from portkey_ai._vendor.openai._utils import is_given, strip_not_given
assert is_given(external_types.NOT_GIVEN) == False  # ✓
assert strip_not_given({'a': 1, 'b': external_types.NOT_GIVEN}) == {'a': 1}  # ✓
```