### PR TITLE
fix(base_client): return recursive _request() result on retry

### DIFF
--- a/portkey_ai/api_resources/base_client.py
+++ b/portkey_ai/api_resources/base_client.py
@@ -675,7 +675,7 @@ class APIClient:
             # to completion before attempting to access the response text.
 
             if retry_count < self.max_retries and self._should_retry(err.response):
-                self._request(
+                return self._request(
                     options=options,
                     stream=stream,
                     cast_to=cast_to,
@@ -688,7 +688,7 @@ class APIClient:
             raise APITimeoutError(request=request) from err
         except Exception as err:
             if retry_count < self.max_retries:
-                self._request(
+                return self._request(
                     options=options,
                     stream=stream,
                     cast_to=cast_to,
@@ -1388,7 +1388,7 @@ class AsyncAPIClient:
             # If the response is streamed then we need to explicitly read the response
             # to completion before attempting to access the response text.
             if retry_count < self.max_retries and self._should_retry(err.response):
-                await self._request(
+                return await self._request(
                     options=options,
                     stream=stream,
                     cast_to=cast_to,
@@ -1401,7 +1401,7 @@ class AsyncAPIClient:
             raise APITimeoutError(request=request) from err
         except Exception as err:
             if retry_count < self.max_retries:
-                await self._request(
+                return await self._request(
                     options=options,
                     stream=stream,
                     cast_to=cast_to,


### PR DESCRIPTION
## Summary

  - `_request()` (sync + async) calls itself recursively on retry but was
    missing `return`, so the retry result was silently discarded and the
    original exception was always re-raised — even when the retry succeeded.
  - Added `return` / `return await` before all 4 recursive `_request()` calls
    in `base_client.py`.

  ## Root Cause

  In both the `httpx.HTTPStatusError` and generic `Exception` retry paths,
  the recursive call was fire-and-forget: